### PR TITLE
fix no stress toggle not working

### DIFF
--- a/Trainer_v5/Trainer.Source/Helpers.cs
+++ b/Trainer_v5/Trainer.Source/Helpers.cs
@@ -7,7 +7,7 @@ namespace Trainer_v5
 	public static class Helpers
 	{
 		public static bool IsGameLoaded => GameSettings.Instance != null && HUD.Instance != null;
-		public static string Version => "5.1.8";
+		public static string Version => "5.1.9";
 		public static string TrainerVersion => $"Trainer v{Version}";
 		public static bool IsDebug => false;
 		public static string DiscordUrl => "https://discord.com/invite/J584aG";

--- a/Trainer_v5/Trainer.Source/SettingsWindow.cs
+++ b/Trainer_v5/Trainer.Source/SettingsWindow.cs
@@ -89,7 +89,7 @@ namespace Trainer_v5
 			column2.Add(UIHelper.CreateLabel());
 
 			column2.Add(UIHelper.CreateToggle("DisableNeeds".LocDef("Disable Needs"), settings.Get("NoNeeds"), a => settings.Toggle("NoNeeds")));
-			column2.Add(UIHelper.CreateToggle("DisableStress".LocDef("Disable Stress"), settings.Get("DisableStress"), a => settings.Toggle("DisableStress")));
+			column2.Add(UIHelper.CreateToggle("DisableStress".LocDef("Disable Stress"), settings.Get("NoStress"), a => settings.Toggle("NoStress")));
 			column2.Add(UIHelper.CreateToggle("FreeEmployees".LocDef("Free Employees"), settings.Get("FreeEmployees"), a => settings.Toggle("FreeEmployees")));
 			column2.Add(UIHelper.CreateToggle("FreeStaff".LocDef("Free Staff"), settings.Get("FreeStaff"), a => settings.Toggle("FreeStaff")));
 			column2.Add(UIHelper.CreateToggle("FullSatisfaction".LocDef("Full Satisfaction"), settings.Get("FullSatisfaction"), a => settings.Toggle("FullSatisfaction")));

--- a/Trainer_v5/Trainer.Source/TrainerBehaviour.cs
+++ b/Trainer_v5/Trainer.Source/TrainerBehaviour.cs
@@ -238,7 +238,7 @@ namespace Trainer_v5
 
 				if (Helpers.GetProperty(TrainerSettings, "NoStress"))
 				{
-					employee.Stress = 1;
+					employee.Stress = 1f;
 				}
 
 				if (employee.RoleString.Contains("Lead") && Helpers.GetProperty(StoresSettings, "LeadEfficiencyStore") != null)


### PR DESCRIPTION
No stress "Disable stress" toggle wasn't working due to the settings window and dictionary naming being out of sync.