### PR TITLE
Trainer quality improvements

### DIFF
--- a/Trainer_v5/Trainer.Source/Extensions.cs
+++ b/Trainer_v5/Trainer.Source/Extensions.cs
@@ -41,16 +41,17 @@ namespace Trainer_v5
 
 		public static int GetIndex(this Dictionary<string, object> items, Dictionary<string, object> settings, string key, int valueType)
 		{
+			var stored = settings.Get(key);
 			switch (valueType)
 			{
 				case 1:
-					return items.FindIndex(x => x.Value.MakeInt() == settings.Get(key).MakeInt());
+					return stored == null ? 0 : items.FindIndex(x => x.Value.MakeInt() == stored.MakeInt());
 				case 2:
-					return items.FindIndex(x => x.Value.MakeFloat() == settings.Get(key).MakeFloat());
+					return stored == null ? 0 : items.FindIndex(x => x.Value.MakeFloat() == stored.MakeFloat());
 				case 3:
-					return items.FindIndex(x => x.Value.MakeString() == settings.Get(key).MakeString());
+					return stored == null ? 0 : items.FindIndex(x => x.Value.MakeString() == stored.MakeString());
 				case 4:
-					return items.FindIndex(x => x.Value.MakeBool() == settings.Get(key).MakeBool());
+					return stored == null ? 0 : items.FindIndex(x => x.Value.MakeBool() == stored.MakeBool());
 				default:
 					"Method GetIndex received an unknown value type as parameter".Log();
 					return -1;

--- a/Trainer_v5/Trainer.Source/Helpers.cs
+++ b/Trainer_v5/Trainer.Source/Helpers.cs
@@ -150,6 +150,7 @@ namespace Trainer_v5
 			catch (Exception ex)
 			{
 				ex.LogException();
+				UnityEngine.Debug.LogException(ex);
 			}
 		}
 
@@ -159,7 +160,11 @@ namespace Trainer_v5
 
 		public static Employee.EmployeeRole ToEmployeeRole(this string str)
 		{
-			return (Employee.EmployeeRole)Enum.Parse(typeof(Employee.EmployeeRole), str);
+			Employee.EmployeeRole role;
+			if (Enum.TryParse(str, out role))
+				return role;
+			$"ToEmployeeRole: unknown role '{str}', defaulting to Programmer".Log();
+			return Employee.EmployeeRole.Programmer;
 		}
 
 		#endregion

--- a/Trainer_v5/Trainer.Source/InputHelper.cs
+++ b/Trainer_v5/Trainer.Source/InputHelper.cs
@@ -34,7 +34,8 @@ namespace Trainer_v5
 				input =>
 				{
 					var val = TryParseAndValidate(input, float.TryParse, min, max);
-					onFinish.Invoke(val.Value);
+					if (val.HasValue)
+						onFinish.Invoke(val.Value);
 				});
 		}
 


### PR DESCRIPTION
## Summary

- Fix null-reference crash in `InputHelper` — `onFinish.Invoke(val.Value)` called without `HasValue` guard
- Fix null-reference crash in `Extensions.GetIndex` — `settings.Get(key)` could return null before `.MakeFloat()/.MakeInt()` call
- Improve `Helpers.TryExecute` exception visibility — add `Debug.LogException` so Unity surfaces full stack trace
- Fix `Helpers.ToEmployeeRole` — replace throwing `Enum.Parse` with safe `Enum.TryParse` + fallback

## Planned follow-up commits (chunk by chunk)
- Quick wins (Logger nameof fix, Discord URL unification, `IsGameReady()` helper, Constants row derivation)
- Magic numbers → named constants in `Constants.cs`
- TODO feature completions (bookshelf aura reset, FreePrint default restore)
- XML documentation
- Dynamic UI generation for `SettingsWindow`

## Test plan
- [ ] Enter invalid input in any float dialog — no crash, shows error notification
- [ ] Open settings window with uninitialized efficiency stores — no crash
- [ ] Trigger a `TryExecute` failure — full stack trace visible in Unity console
- [ ] Verify trainer loads normally with no NullReferenceExceptions on startup

https://claude.ai/code/session_019b1PQK6ghTTzhvH2saDTam

---
_Generated by [Claude Code](https://claude.ai/code/session_019b1PQK6ghTTzhvH2saDTam)_