### PR TITLE
Quick wins: Logger fix, Discord URL, IsGameReady helper

### DIFF
--- a/Trainer_v5/Trainer.Source/Logger.cs
+++ b/Trainer_v5/Trainer.Source/Logger.cs
@@ -5,7 +5,7 @@ namespace Trainer_v5
 {
 	public static class Logger
 	{
-		private static void ConsoleLogWithPropertyName(string str) => DevConsole.Console.Log($"Trainer Property {nameof(str)}: {str}");
+		private static void ConsoleLogWithPropertyName(string str) => DevConsole.Console.Log($"Trainer: {str}");
 		private static void ConsoleLog(string str) => DevConsole.Console.Log(str);
 
 		public static void Log(this string str, bool withPropertyName = true)

--- a/Trainer_v5/Trainer.Source/TrainerBehaviour.cs
+++ b/Trainer_v5/Trainer.Source/TrainerBehaviour.cs
@@ -11,6 +11,9 @@ namespace Trainer_v5
 	public class TrainerBehaviour : ModBehaviour
 	{
 		private static bool _specializationsLoaded;
+
+		private static bool IsGameReady(bool requireSelector = false) =>
+			Helpers.IsGameLoaded && (!requireSelector || SelectorController.Instance != null);
 		private float _defaultEnvironmentISPCostFactor;
 
 		private static GameSettings Settings => GameSettings.Instance;
@@ -584,7 +587,7 @@ namespace Trainer_v5
 
 		public static void ShowDiscordInvite(bool displayAsPopup = false)
 		{
-			string message = "Join us on our discord server\nhttps://discord.gg/NQpm5kn";
+			string message = $"Join us on our discord server\n{Helpers.DiscordUrl}";
 			if (displayAsPopup)
 			{
 				HUD.Instance.AddPopupMessage(message, "Cogs", PopupManager.PopUpAction.None, 0, 0, 0, 0);
@@ -733,10 +736,7 @@ namespace Trainer_v5
 
 		public static void HREmployees()
 		{
-			if (!Helpers.IsGameLoaded || SelectorController.Instance == null)
-			{
-				return;
-			}
+			if (!IsGameReady(requireSelector: true)) return;
 
 			Actor[] Actors = Settings.sActorManager.Actors
 									 .Where(actor => actor.employee.RoleString.Contains("Lead"))
@@ -829,10 +829,7 @@ namespace Trainer_v5
 			SoftwareType[] softwareTypes = MarketSimulation.Active.SoftwareTypes.Values.ToArray();
 			Employee.EmployeeRole[] employeeRoles = (Employee.EmployeeRole[])Enum.GetValues(typeof(Employee.EmployeeRole));
 
-			if (!Helpers.IsGameLoaded || SelectorController.Instance == null)
-			{
-				return;
-			}
+			if (!IsGameReady(requireSelector: true)) return;
 
 			foreach (Actor actor in Settings.sActorManager.Actors.ToArray())
 			{
@@ -864,10 +861,7 @@ namespace Trainer_v5
 
 		public static void UnlockAllSpace()
 		{
-			if (!Helpers.IsGameLoaded)
-			{
-				return;
-			}
+			if (!IsGameReady()) return;
 
 			Example.TakeAllLand();
 			HUD.Instance.AddPopupMessage("Trainer: All plots has been unlocked!", "Cogs", PopupManager.PopUpAction.None, 0, 0, 0, 0);
@@ -875,10 +869,7 @@ namespace Trainer_v5
 
 		public static void UnlockFurniture()
 		{
-			if (!Helpers.IsGameLoaded)
-			{
-				return;
-			}
+			if (!IsGameReady()) return;
 
 			Example.UnlockFurniture();
 			Cheats.UnlockFurn = true;


### PR DESCRIPTION
## Summary

- **Logger** — `nameof(str)` always resolved to the literal `"str"` at compile time, producing useless output like `"Trainer Property str: value"`. Now outputs `"Trainer: value"`.
- **Discord URL** — `ShowDiscordInvite` had a different hardcoded shortlink (`discord.gg/NQpm5kn`) vs `Helpers.DiscordUrl` (`discord.com/invite/J584aG`). Now uses `Helpers.DiscordUrl` as the single source of truth.
- **`IsGameReady()` helper** — Extracted `private static bool IsGameReady(bool requireSelector = false)` and replaced 4 repeated inline null guards across `HREmployees`, `EmployeesToMax`, `UnlockAllSpace`, and `UnlockFurniture`.

## Test plan
- [ ] Trigger any `.Log()` call — output reads `"Trainer: <message>"`, not `"Trainer Property str: <message>"`
- [ ] Click Discord button — URL matches `Helpers.DiscordUrl`
- [ ] Call `HREmployees` / `EmployeesToMax` with game not loaded — returns cleanly without crash

https://claude.ai/code/session_019b1PQK6ghTTzhvH2saDTam

---
_Generated by [Claude Code](https://claude.ai/code/session_019b1PQK6ghTTzhvH2saDTam)_