### PR TITLE
Promote More Inspiration & More Creativity to main settings panel

### DIFF
--- a/Trainer_v5/Trainer.Source/SettingsWindow.cs
+++ b/Trainer_v5/Trainer.Source/SettingsWindow.cs
@@ -151,6 +151,8 @@ namespace Trainer_v5
 			column4.Add(UIHelper.CreateToggle("DisableForcePause".LocDef("Disable Force Pause"), settings.Get("DisableForcePause"), a => settings.Toggle("DisableForcePause")));
 			column4.Add(UIHelper.CreateToggle("DisableForceFreeze".LocDef("Disable Force Freeze"), settings.Get("DisableForceFreeze"), a => settings.Toggle("DisableForceFreeze")));
 			column4.Add(UIHelper.CreateToggle("AutoAcceptHostingDeals".LocDef("Auto Accept Hosting Deals"), settings.Get("AutoAcceptHostingDeals"), a => settings.Toggle("AutoAcceptHostingDeals")));
+			column4.Add(UIHelper.CreateToggle("MoreInspiration".LocDef("More Inspiration"), settings.Get("MoreInspiration"), a => settings.Toggle("MoreInspiration")));
+			column4.Add(UIHelper.CreateToggle("MoreCreativity".LocDef("More Creativity"), settings.Get("MoreCreativity"), a => settings.Toggle("MoreCreativity")));
 
 			#endregion
 
@@ -191,8 +193,7 @@ namespace Trainer_v5
 				bool isOn = false;
 				column6.Add(UIHelper.CreateToggle("TestToggle".LocDef("Test Toggle"), isOn, a => isOn = !isOn));
 				column6.Add(UIHelper.CreateButton("TestButton".LocDef("Test Button"), TrainerBehaviour.TestButton));
-				column6.Add(UIHelper.CreateToggle("MoreInspiration".LocDef("More Inspiration [TEST]"), settings.Get("MoreInspiration"), a => settings.Toggle("MoreInspiration")));
-				column6.Add(UIHelper.CreateToggle("MoreCreativity".LocDef("More Creativity [TEST]"), settings.Get("MoreCreativity"), a => settings.Toggle("MoreCreativity")));
+
 			}
 
 			#endregion


### PR DESCRIPTION
## Summary

- Moves **More Inspiration** and **More Creativity** toggles from the experimental-only section (column 6) into the main settings panel (column 4), making them available to all users without needing to enable experimental mode
- Removes the `[TEST]` label suffix from both toggles

## What these toggles do

- **More Inspiration** — resets each employee's `LastInpirationUse` every frame, giving them unlimited inspiration
- **More Creativity** — calls `RevealCreativity(1f)` every frame, keeping every employee's creativity revealed and at full value

## Test plan

- [ ] Open trainer settings window without enabling Experimental mode
- [ ] Confirm **More Inspiration** and **More Creativity** toggles are visible in column 4
- [ ] Enable each toggle and verify the effect applies to employees in-game
- [ ] Confirm column 6 / experimental section no longer shows these toggles

Closes #8

https://claude.ai/code/session_01HthKrc8c9VJJJZqmcarRbW

---
_Generated by [Claude Code](https://claude.ai/code/session_01HthKrc8c9VJJJZqmcarRbW)_