### PR TITLE
Replace magic numbers with named constants

### DIFF
--- a/Trainer_v5/Trainer.Source/Constants.cs
+++ b/Trainer_v5/Trainer.Source/Constants.cs
@@ -23,5 +23,20 @@
 		public const int SIXTH_ROW = 5 * ELEMENT_HEIGHT;
 		public const int SEVENTH_ROW = 6 * ELEMENT_HEIGHT;
 		public const int EIGHTH_ROW = 7 * ELEMENT_HEIGHT;
+
+		public const float BOOKSHELF_AURA_BOOSTED = 0.75f;
+		public const float CHAIR_COMFORT_LOW       = 1.2f;
+		public const float CHAIR_COMFORT_HIGH      = 1.5f;
+		public const int   ENV_FULL                = 8;
+		public const int   ROOM_BRIGHTNESS_FULL    = 16;
+		public const int   MAX_FLOOR               = 100;
+		public const int   MAX_BOXES_BOOSTED       = 108;
+		public const int   MAX_BOXES_DEFAULT       = 54;
+		public const int   MAX_CARRY_BOOSTED       = 18;
+		public const int   MAX_CARRY_DEFAULT       = 9;
+		public const float EXPANSION_COST          = 350f;
+		public const float EXPANSION_COST_HALF     = 175f;
+		public const float WALK_SPEED_BOOSTED      = 4f;
+		public const float WALK_SPEED_DEFAULT      = 2f;
 	}
 }

--- a/Trainer_v5/Trainer.Source/TrainerBehaviour.cs
+++ b/Trainer_v5/Trainer.Source/TrainerBehaviour.cs
@@ -155,7 +155,7 @@ namespace Trainer_v5
 
 				if (Helpers.GetProperty(TrainerSettings, "IncreaseBookshelfSkill") && furniture.Type == "Bookshelf")
 				{
-					furniture.AuraValues[1] = 0.75f;
+					furniture.AuraValues[1] = Constants.BOOKSHELF_AURA_BOOSTED;
 				}
 
 				//TODO: else 0.25
@@ -164,9 +164,9 @@ namespace Trainer_v5
 					switch (furniture.Type)
 					{
 						case "Chair":
-							if (furniture.Comfort < 1.2f)
+							if (furniture.Comfort < Constants.CHAIR_COMFORT_LOW)
 							{
-								furniture.Comfort = 1.5f;
+								furniture.Comfort = Constants.CHAIR_COMFORT_HIGH;
 							}
 							goto case "Ventilation";
 						case "CCTV":
@@ -207,12 +207,12 @@ namespace Trainer_v5
 
 				if (Helpers.GetProperty(TrainerSettings, "FullEnvironment"))
 				{
-					room.FurnEnvironment = 8;
+					room.FurnEnvironment = Constants.ENV_FULL;
 				}
 
 				if (Helpers.GetProperty(TrainerSettings, "FullRoomBrightness"))
 				{
-					room.IndirectLighting = 16;
+					room.IndirectLighting = Constants.ROOM_BRIGHTNESS_FULL;
 				}
 
 				if (Helpers.GetProperty(TrainerSettings, "NoSickness"))
@@ -311,7 +311,7 @@ namespace Trainer_v5
 					employee.RevealCreativity(1f);
 				}
 
-				actor.WalkSpeed = Helpers.GetProperty(TrainerSettings, "IncreaseWalkSpeed") ? 4f : 2f;
+				actor.WalkSpeed = Helpers.GetProperty(TrainerSettings, "IncreaseWalkSpeed") ? Constants.WALK_SPEED_BOOSTED : Constants.WALK_SPEED_DEFAULT;
 			}
 
 			if (Helpers.GetProperty(TrainerSettings, "MoreHostingDeals"))
@@ -556,13 +556,13 @@ namespace Trainer_v5
 #endif
 			}
 
-			GameSettings.MaxFloor = 100; //10 default
-			AI.MaxBoxes = Helpers.GetProperty(TrainerSettings, "IncreaseCourierCapacity") ? 108 : 54;
-			AI.MaxBoxCarry = Helpers.GetProperty(TrainerSettings, "IncreaseCourierCapacity") ? 18 : 9;
+			GameSettings.MaxFloor = Constants.MAX_FLOOR;
+			AI.MaxBoxes = Helpers.GetProperty(TrainerSettings, "IncreaseCourierCapacity") ? Constants.MAX_BOXES_BOOSTED : Constants.MAX_BOXES_DEFAULT;
+			AI.MaxBoxCarry = Helpers.GetProperty(TrainerSettings, "IncreaseCourierCapacity") ? Constants.MAX_CARRY_BOOSTED : Constants.MAX_CARRY_DEFAULT;
 			//Not working
 			//AI.BoxPrice = Helpers.GetProperty(TrainerSettings, "ReduceBoxPrice") ? 62.5f : 125;
 			Settings.Environment.ISPCostFactor = Helpers.GetProperty(TrainerSettings, "ReduceISPCost") ? _defaultEnvironmentISPCostFactor / 2f : _defaultEnvironmentISPCostFactor;
-			Settings.ExpansionCost = Helpers.GetProperty(TrainerSettings, "ReduceExpansionCost") ? 175f : 350f;
+			Settings.ExpansionCost = Helpers.GetProperty(TrainerSettings, "ReduceExpansionCost") ? Constants.EXPANSION_COST_HALF : Constants.EXPANSION_COST;
 		}
 
 		private static void LoadSpecializations()


### PR DESCRIPTION
## Summary

Add 14 named constants to `Constants.cs` and replace all matching literals in `TrainerBehaviour.cs`:

| Constant | Value | Replaces |
|----------|-------|---------|
| `BOOKSHELF_AURA_BOOSTED` | `0.75f` | `furniture.AuraValues[1] = 0.75f` |
| `CHAIR_COMFORT_LOW` | `1.2f` | comfort threshold check |
| `CHAIR_COMFORT_HIGH` | `1.5f` | comfort set value |
| `ENV_FULL` | `8` | `room.FurnEnvironment = 8` |
| `ROOM_BRIGHTNESS_FULL` | `16` | `room.IndirectLighting = 16` |
| `WALK_SPEED_BOOSTED` | `4f` | walk speed toggle |
| `WALK_SPEED_DEFAULT` | `2f` | walk speed toggle |
| `MAX_FLOOR` | `100` | `GameSettings.MaxFloor = 100` |
| `MAX_BOXES_BOOSTED` | `108` | courier capacity toggle |
| `MAX_BOXES_DEFAULT` | `54` | courier capacity toggle |
| `MAX_CARRY_BOOSTED` | `18` | courier carry toggle |
| `MAX_CARRY_DEFAULT` | `9` | courier carry toggle |
| `EXPANSION_COST` | `350f` | expansion cost toggle |
| `EXPANSION_COST_HALF` | `175f` | expansion cost toggle |

## Test plan
- [ ] Build with no compiler errors
- [ ] Furniture aura boost, room environment, courier capacity, expansion cost all behave as before

https://claude.ai/code/session_019b1PQK6ghTTzhvH2saDTam

---
_Generated by [Claude Code](https://claude.ai/code/session_019b1PQK6ghTTzhvH2saDTam)_