### PR TITLE
fix: reinstall detail window buttons after scene reload

### DIFF
--- a/Trainer_v5/Trainer.Source/DetailWindowTrainer.cs
+++ b/Trainer_v5/Trainer.Source/DetailWindowTrainer.cs
@@ -9,6 +9,11 @@ namespace Trainer_v5
 	{
 		private static bool _installed;
 
+		public static void Reset()
+		{
+			_installed = false;
+		}
+
 		private static Employee CurrentEmployee => HUD.Instance.DetailWindow?.CurrentEmployee?.employee;
 
 		public static void Install()

--- a/Trainer_v5/Trainer.Source/TrainerBehaviour.cs
+++ b/Trainer_v5/Trainer.Source/TrainerBehaviour.cs
@@ -41,6 +41,7 @@ namespace Trainer_v5
 							Destroy(Main.TrainerButton.gameObject);
 							Destroy(Main.SkillChangeButton.gameObject);
 						}
+						DetailWindowTrainer.Reset();
 						UnsubscribeFromEvents();
 						break;
 					case "MainScene":


### PR DESCRIPTION
## Problem
The Trait / Demand / Creativity / Inspiration / LeadSpec buttons in the employee Detail window disappear after loading a save or returning from the main menu.

**Root cause:** `DetailWindowTrainer._installed` is a `static bool`. Once set to `true` on the first scene load, subsequent calls to `Install()` bail out immediately via the early-return guard — even though Unity destroyed the `DetailWindow` GameObject (and all attached trainer buttons) during the scene transition.

## Fix
Expose a `Reset()` method on `DetailWindowTrainer` that clears `_installed`, and call it in the `"MainMenu"` branch of `OnLevelFinishedLoading`. The next `"MainScene"` load will then re-run `Install()` and reattach the buttons to the freshly created `DetailWindow`.

## Files changed
- `DetailWindowTrainer.cs` — added `public static void Reset()`
- `TrainerBehaviour.cs` — added `DetailWindowTrainer.Reset()` call in MainMenu case

## Related reports
Multiple users (Bohica, Zalfir, Drillien, SneakyPT, Benjamin, Martins, kswro, RedStone) reported buttons disappearing after every save load or building change.

---
_Generated by [Claude Code](https://claude.ai/code/session_015d957fPRzykTabhNhv3fzZ)_