### PR TITLE
fix: stop event handlers accumulating on every scene load

### DIFF
--- a/Trainer_v5/Trainer.Source/TrainerBehaviour.cs
+++ b/Trainer_v5/Trainer.Source/TrainerBehaviour.cs
@@ -60,16 +60,16 @@ namespace Trainer_v5
 
 		private void SubscribeToEvents()
 		{
-			TimeOfDay.OnHourPassed += (obj, args) => OnHourPassed(obj, args);
-			TimeOfDay.OnDayPassed += (obj, args) => OnDayPassed(obj, args);
-			TimeOfDay.OnMonthPassed += (obj, args) => OnMonthPassed(obj, args);
+			TimeOfDay.OnHourPassed += OnHourPassed;
+			TimeOfDay.OnDayPassed += OnDayPassed;
+			TimeOfDay.OnMonthPassed += OnMonthPassed;
 		}
 
 		private void UnsubscribeFromEvents()
 		{
-			TimeOfDay.OnHourPassed -= (obj, args) => OnHourPassed(obj, args);
-			TimeOfDay.OnDayPassed -= (obj, args) => OnDayPassed(obj, args);
-			TimeOfDay.OnMonthPassed -= (obj, args) => OnMonthPassed(obj, args);
+			TimeOfDay.OnHourPassed -= OnHourPassed;
+			TimeOfDay.OnDayPassed -= OnDayPassed;
+			TimeOfDay.OnMonthPassed -= OnMonthPassed;
 		}
 
 		private void OnHourPassed(object obj, EventArgs args)


### PR DESCRIPTION
## Problem
Each time a save is loaded (or the main menu is revisited), `SubscribeToEvents()` adds a new set of handlers and `UnsubscribeFromEvents()` silently does nothing — causing handlers to accumulate indefinitely.

**Root cause:** `+=` with a lambda creates a new `EventHandler` delegate instance. The `-=` in `UnsubscribeFromEvents()` also creates a new instance; since it never matches any previously subscribed delegate, no handler is ever removed. After N loads, `OnMonthPassed` fires N times per in-game month.

**Consequences observed by users:**
- UI slowdown / unresponsive UI (Beats) — CPU overhead compounds with each reload
- `LockAge` aging employees at multiples of the expected rate after multiple loads

## Fix
Replace the anonymous lambda wrappers with direct method-group references (`OnHourPassed`, `OnDayPassed`, `OnMonthPassed`). The same delegate object is used for both `+=` and `-=`, so unsubscription works correctly.

## Files changed
- `TrainerBehaviour.cs` — `SubscribeToEvents()` / `UnsubscribeFromEvents()`

---
_Generated by [Claude Code](https://claude.ai/code/session_015d957fPRzykTabhNhv3fzZ)_