### PR TITLE
fix: recall employees already on vacation or sick when toggles enabled

### DIFF
--- a/Trainer_v5/Trainer.Source/TrainerBehaviour.cs
+++ b/Trainer_v5/Trainer.Source/TrainerBehaviour.cs
@@ -228,12 +228,14 @@ namespace Trainer_v5
 					TimeOfDay.Instance.Sick.Clear();
 
 					if (actor.SpecialState == Actor.HomeState.Sick)
+					{
 						actor.SpecialState = Actor.HomeState.Default;
+						actor.WasSick = true;
+					}
 
 					actor.GermAdd = 0f;
 					actor.GermCount = 0f;
 					actor.SickDays = 0;
-					//actor.WasSick = true;
 				}
 
 				if (Helpers.GetProperty(TrainerSettings, "NoStress"))
@@ -296,6 +298,8 @@ namespace Trainer_v5
 				if (Helpers.GetProperty(TrainerSettings, "NoVacation"))
 				{
 					actor.VacationMonth = SDateTime.NextMonth(24);
+					if (actor.SpecialState == Actor.HomeState.Vacation)
+						actor.SpecialState = Actor.HomeState.Default;
 				}
 
 				if (Helpers.GetProperty(TrainerSettings, "MoreInspiration"))


### PR DESCRIPTION
## Problem
Enabling **No Vacation** or **No Sickness** prevented *future* absences but had no effect on employees already at home — they stayed absent until the period ended naturally. Users reported the options "just disable the messages" (I.R. Baboon, Septus).

## Root causes

**NoVacation** — only pushed `actor.VacationMonth` 24 months forward. Employees already in `HomeState.Vacation` were never touched.

**NoSickness** — correctly reset `HomeState.Sick → Default`, but left `actor.WasSick = false` (was commented out). The game's return-to-work logic may check `WasSick` to decide whether to send the actor back; leaving it false could keep them home.

## Fix
- **NoVacation**: add an every-frame check — if `SpecialState == Vacation`, reset it to `Default` immediately.
- **NoSickness**: set `actor.WasSick = true` alongside the state reset so the game treats the employee as recovered.

## Files changed
- `TrainerBehaviour.cs` — NoVacation and NoSickness blocks in `Update()`

## Related reports
I.R. Baboon, Septus

---
_Generated by [Claude Code](https://claude.ai/code/session_015d957fPRzykTabhNhv3fzZ)_