### PR TITLE
fix: show error and fall back to DetailWindow actor when selection is lost

### DIFF
--- a/Trainer_v5/Trainer.Source/Window/EmployeeDemandChangeWindow.cs
+++ b/Trainer_v5/Trainer.Source/Window/EmployeeDemandChangeWindow.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Trainer_v5.SDK;
@@ -12,10 +12,11 @@ namespace Trainer_v5.Window
 	{
 		public static EmployeeDemandChangeWindow Instance => _instance.Value;
 		private static readonly Lazy<EmployeeDemandChangeWindow> _instance = new Lazy<EmployeeDemandChangeWindow>(() => new EmployeeDemandChangeWindow());
-		
+
 		private GUIWindow _window;
 		private Dictionary<LeadDesignDemands.Demand, Toggle> _demandToggles;
 		private Actor _actor;
+		private bool _isRefreshing;
 
 		public void Show()
 		{
@@ -36,16 +37,18 @@ namespace Trainer_v5.Window
 			}
 
 			var selectedActors = SelectorController.Instance.Selected.OfType<Actor>();
-			_actor = selectedActors.Any() ? selectedActors.First() : null;
+			_actor = selectedActors.FirstOrDefault() ?? HUD.Instance.DetailWindow?.CurrentEmployee;
 			var employee = _actor?.employee;
 
 			window.InitialTitle = window.TitleText.text = window.NonLocTitle = $"Edit demands for {employee?.Name ?? "Nobody"}";
 
+			_isRefreshing = true;
 			foreach (var pair in _demandToggles)
 			{
 				var isOn = employee?.HasDemanded(pair.Key) ?? false;
 				pair.Value.isOn = isOn;
 			}
+			_isRefreshing = false;
 		}
 
 		private void CreateWindow()
@@ -56,14 +59,14 @@ namespace Trainer_v5.Window
 			window.name = "EditDemands";
 			window.MainPanel.name = "EditDemandsPanel";
 
-			var demands = EmployeeHelper.Demands.ToDictionary(t => t, t => 
+			var demands = EmployeeHelper.Demands.ToDictionary(t => t, t =>
 				UIFactory.Toggle(t.ToString(), false, on => ToggleDemand(t, on)));
 
 			var col1 = new List<GameObject> { UIFactory.Label("Demands", WindowStyles.TitleStyle).gameObject };
 			col1.AddRange(demands.Values.Select(e => e.gameObject));
 			col1.Add(UIFactory.Button("Refresh", () => self.Refresh()).gameObject);
 
-			Utils.CreateGameObjects(Constants.FIRST_COLUMN,  col1.ToArray(), window);
+			Utils.CreateGameObjects(Constants.FIRST_COLUMN, col1.ToArray(), window);
 
 			var maxRows = new[] { col1.Count }.Max();
 			Utils.SetWindowSize(maxRows + 1, Constants.SECOND_COLUMN - 1, window);
@@ -75,7 +78,11 @@ namespace Trainer_v5.Window
 		private void ToggleDemand(LeadDesignDemands.Demand demand, bool on)
 		{
 			if (_actor == null)
+			{
+				if (!_isRefreshing)
+					Notification.ShowError("Select an employee first.");
 				return;
+			}
 			var employee = _actor.employee;
 
 			var has = (employee.DemandResults & demand) > 0;

--- a/Trainer_v5/Trainer.Source/Window/EmployeeTraitChangeWindow.cs
+++ b/Trainer_v5/Trainer.Source/Window/EmployeeTraitChangeWindow.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Trainer_v5.SDK;
@@ -12,10 +12,11 @@ namespace Trainer_v5.Window
 	{
 		public static EmployeeTraitChangeWindow Instance => _instance.Value;
 		private static readonly Lazy<EmployeeTraitChangeWindow> _instance = new Lazy<EmployeeTraitChangeWindow>(() => new EmployeeTraitChangeWindow());
-		
+
 		private GUIWindow _window;
 		private Dictionary<Employee.Trait, Toggle> _traitsToggles;
 		private Actor _actor;
+		private bool _isRefreshing;
 
 		public void Show()
 		{
@@ -36,16 +37,18 @@ namespace Trainer_v5.Window
 			}
 
 			var selectedActors = SelectorController.Instance.Selected.OfType<Actor>();
-			_actor = selectedActors.Any() ? selectedActors.First() : null;
+			_actor = selectedActors.FirstOrDefault() ?? HUD.Instance.DetailWindow?.CurrentEmployee;
 			var employee = _actor?.employee;
 
 			window.InitialTitle = window.TitleText.text = window.NonLocTitle = $"Edit traits for {employee?.Name ?? "Nobody"}";
 
+			_isRefreshing = true;
 			foreach (var pair in _traitsToggles)
 			{
 				var isOn = employee?.HasTrait(pair.Key) ?? false;
 				pair.Value.isOn = isOn;
 			}
+			_isRefreshing = false;
 		}
 
 		private void CreateWindow()
@@ -56,7 +59,7 @@ namespace Trainer_v5.Window
 			window.name = "EditTrait";
 			window.MainPanel.name = "EditTraitPanel";
 
-			var traits = EmployeeHelper.Traits.ToDictionary(t => t, t => 
+			var traits = EmployeeHelper.Traits.ToDictionary(t => t, t =>
 				UIFactory.Toggle(t.ToString(), false, on => ToggleTrait(t, on)));
 
 			var goodTraitsToggle = traits
@@ -93,7 +96,11 @@ namespace Trainer_v5.Window
 		private void ToggleTrait(Employee.Trait trait, bool on)
 		{
 			if (_actor == null)
+			{
+				if (!_isRefreshing)
+					Notification.ShowError("Select an employee first.");
 				return;
+			}
 			var employee = _actor.employee;
 
 			var hasTrait = (employee.Traits & trait) > 0;


### PR DESCRIPTION
## Problem
Trait and Demand toggle clicks silently did nothing when no employee was selected, giving the user no feedback that their action was ignored.

**Root cause:** `_actor` was resolved only from `SelectorController.Instance.Selected`. Clicking the **Trait** / **Demand** buttons in the Detail window doesn't guarantee the employee is also box-selected in the global selection controller. When the two were out of sync, `_actor` was `null` and every toggle change was swallowed with a silent `return`.

## Fix

### 1. Actor fallback
`Refresh()` in both windows now resolves `_actor` as:
```csharp
_actor = selectedActors.FirstOrDefault()
      ?? HUD.Instance.DetailWindow?.CurrentEmployee;
```
This covers the common case of clicking the trainer buttons from the Detail window without an explicit box-select.

### 2. User-facing error
`ToggleTrait` / `ToggleDemand` now call `Notification.ShowError("Select an employee first.")` when `_actor` is still `null` after the fallback — so the user knows why their click had no effect.

### 3. Refresh guard
A `_isRefreshing` flag suppresses the error notification during programmatic `Refresh()` calls, which fire toggle callbacks internally while syncing UI state — preventing a flood of error popups when the window opens with no selection.

## Files changed
- `EmployeeTraitChangeWindow.cs`
- `EmployeeDemandChangeWindow.cs`

## Related reports
RedStone — "Traits aren't working. I click checkmark but it don't apply."

---
_Generated by [Claude Code](https://claude.ai/code/session_015d957fPRzykTabhNhv3fzZ)_