### PR TITLE
Add agent guidelines pack

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,43 @@
+root = true
+
+# Existing repositories should preserve their current indentation style before adopting this file.
+# This repo uses tabs for C# (matching the existing codebase).
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.cs]
+indent_style = tab
+indent_size = 4
+tab_width = 4
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+csharp_style_namespace_declarations = file_scoped:suggestion
+csharp_prefer_braces = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = false:suggestion
+csharp_style_var_for_built_in_types = false:suggestion
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.{sh,bash}]
+indent_style = tab
+indent_size = 4
+
+[*.{json,yml,yaml,xml,csproj,sln}]
+indent_style = space
+indent_size = 2

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+# Pull Request
+
+<!-- Do not mention AI assistant/tool/model names in the title, branch name, description, changelog, release notes, or helper text. -->
+
+## Summary
+- 
+
+## Changes
+- 
+
+## Requirements / Spec Alignment
+- [ ] Issue / acceptance criteria reviewed if provided
+- [ ] Conflicts or unclear requirements reported
+
+## Documentation
+- [ ] README.md updated if needed
+- [ ] CHANGELOG.md updated if needed
+- [ ] FEATURES.md updated if needed
+- [ ] No invented features, claims, or compatibility guarantees
+
+## Validation
+- [ ] `dotnet format --verify-no-changes`
+- [ ] `dotnet build`
+- [ ] `dotnet test`
+- [ ] Smoke/manual check ran where practical
+- [ ] Implementation rechecked against task and changed files
+
+## Branching / Merge Safety
+- [ ] Work was done on a task branch
+- [ ] PR targets `dev` (features/bugfixes/chores) or `main` (releases/hotfixes)
+- [ ] No auto-merge requested/performed
+- [ ] No branch protection bypass requested/performed
+
+## Notes / Risks
+- 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,386 @@
+# AGENTS.md
+
+Repository-level instructions for AI coding agents.
+
+**Version**: 1.17  
+**Status**: Active  
+**Last Updated**: 2026-06-18
+
+**Recent changes**:
+- Added `MUST` / `SHOULD` / `MAY` strictness levels.
+- Added rule that Git artifacts and PR text must not contain AI assistant, tool, or model names.
+- Clarified that indentation should preserve the existing file/repository style.
+- Added C# control-flow rule forbidding inline guard statements such as `if (...) return ...;`.
+- Added rule to preserve existing Unicode/ASCII punctuation and UI/output separator style.
+- Added C# spacing rule requiring a blank line after a completed control block before the next independent statement.
+- Softened Git Flow and PR requirements for local-only or solo repositories while keeping branch isolation and no auto-merge.
+
+---
+
+## Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.17 | 2026-06-18 | Added C# spacing rule requiring a blank line after a completed control block before the next independent statement. |
+| 1.16 | 2026-06-18 | Added UI/output text style preservation rule for Unicode/ASCII punctuation and decorative separators. |
+| 1.15 | 2026-06-18 | Added C# control-flow convention forbidding inline guard statements such as `if (...) return ...;`. |
+| 1.14 | 2026-06-15 | Added instruction strictness levels, no-AI-name Git artifact rules, indentation preservation guidance, and clearer solo/local workflow handling. |
+| 1.13 | 2026-06-12 | Added Claude Code compatibility through `CLAUDE.md`, cleaned version history, and softened PR workflow wording for solo/local repositories. |
+| 1.12 | 2026-06-12 | Baseline public starter pack with `AGENTS.md`, `README.md`, `CHANGELOG.md`, `FEATURES.md`, `.editorconfig`, PR template, coding convention docs, and FSD/TSD/GDD templates. |
+
+---
+
+## Instruction Strictness
+
+Use these levels when applying this file:
+
+- `MUST`: mandatory safety, correctness, repository hygiene, or user-instruction rule. Do not ignore it unless the user explicitly overrides it in the current task or it is impossible in the environment.
+- `SHOULD`: preferred default. Follow it when practical, but preserve existing repository conventions when they clearly differ.
+- `MAY`: optional guidance for mature projects, larger repositories, or future improvements.
+
+Defaults:
+
+- Safety, secrets, destructive commands, branch protection, no auto-merge, and honesty about validation are `MUST`.
+- Code style, formatting preferences, Git Flow ceremony, and documentation updates are usually `SHOULD` unless the repository makes them mandatory.
+- New child `AGENTS.md` files, new convention files, extra templates, and stricter automation are `MAY` unless requested.
+
+When a rule is too strict for a solo/local repository, keep the intent: isolate the change, document the intended branch/PR, validate what is practical, and never pretend unavailable workflow steps were completed.
+
+---
+
+## Purpose
+
+This file is the source of truth for AI coding agents working in this repository.
+
+Use it as operational guidance, not as a general programming tutorial. Follow these instructions unless a more specific instruction exists in a closer `AGENTS.md` file or the user explicitly overrides them in the current task.
+
+---
+
+## Claude Code Compatibility
+
+`AGENTS.md` is the primary source of truth.
+
+For Claude Code, use the included `CLAUDE.md` wrapper. It imports this file so the same rules can be shared without duplicating instructions.
+
+Do not copy all rules into `CLAUDE.md`. Keep `CLAUDE.md` short and use it only for Claude-Code-specific notes or imports.
+
+---
+
+## Instruction Scope and Precedence
+
+Use the most specific trusted instructions available for the files being changed.
+
+Precedence order:
+
+1. Current user instructions for the task.
+2. The closest `AGENTS.md` in the target repository or subdirectory.
+3. Parent `AGENTS.md` files, moving upward toward the repository root.
+4. General coding knowledge and existing local code style.
+
+Rules:
+
+- Prefer small, targeted changes over broad rewrites.
+- Do not reformat unrelated files.
+- When editing files in multiple subprojects, check the applicable instructions for each changed path.
+- If no repo-specific instructions exist for a subpath, use this file and preserve the existing local style.
+
+---
+
+## Minimal Context Rule
+
+- Apply only the rules relevant to the files touched by the task.
+- Do not rewrite existing code only to satisfy style preferences unless the task asks for cleanup.
+- Do not make broad architecture, formatting, dependency, or naming changes as a side effect.
+- Prefer the smallest safe change that solves the requested problem.
+- When in doubt, preserve the existing local style of the file being edited.
+- Preserve existing indentation style in touched files: use spaces if the file/repo uses spaces, and tabs if it uses tabs.
+- Preserve existing user-facing text style in touched files, including ASCII vs Unicode punctuation, decorative separators, quote style, symbols, labels, and terminal/UI output formatting.
+
+---
+
+## Agent Operating Rules
+
+- Understand the task and inspect the relevant files before editing.
+- Check for applicable convention files under `docs/` before editing code, scripts, or docs.
+- Prefer small, targeted changes over broad rewrites.
+- Do not reformat unrelated files.
+- Preserve existing indentation style in modified files. Do not convert spaces to tabs or tabs to spaces unless the task is explicitly formatting/style cleanup.
+- Preserve existing punctuation and text formatting style in modified user-facing strings.
+- Do not rename public APIs, files, projects, branches, packages, or namespaces unless the task requires it.
+- Do not add new production dependencies unless the task clearly requires them.
+- Preserve existing architecture, project boundaries, and naming patterns.
+- Add or update unit tests when feasible, especially for behavior changes, bug fixes, validation logic, and edge cases.
+- If tests are not added, explain why they were not practical or useful for the change.
+- Always try to build the project when a build command exists and the change affects buildable code.
+- Always try to run relevant tests when test commands or test projects exist.
+- Recheck the implemented behavior against the task and changed files before finishing.
+- If checks cannot be run, state exactly why.
+- If the implementation is uncertain, requirements are ambiguous, or validation cannot prove the behavior, ask or clearly report the uncertainty instead of pretending it is complete.
+- Report what changed, what was validated, and any remaining risks.
+- Do not include AI assistant, tool, or model names in branch names, commit messages, PR titles, PR descriptions, changelog entries, release notes, generated helper text, or user-facing documentation unless the task is explicitly about AI tooling or these agent-guideline files.
+- Never hide failing tests, build errors, skipped checks, or uncertainty.
+
+Ask before:
+
+- broad refactors
+- changing architecture
+- replacing libraries/frameworks
+- changing project structure
+- renaming public APIs
+- changing persistence models
+- changing CI/CD or deployment behavior
+- applying a new pattern across the codebase
+
+---
+
+## Repository Setup and Validation Commands
+
+Before finishing work, run the narrowest relevant checks available in the repository.
+
+Validation priority:
+
+1. Build the affected project when a build command exists.
+2. Run relevant automated tests when they exist.
+3. Run lint/format checks when configured.
+4. Recheck changed behavior against the task.
+
+### .NET / C# Defaults
+
+```bash
+dotnet format --verify-no-changes
+dotnet build
+dotnet test
+```
+
+If formatting changes are expected, run:
+
+```bash
+dotnet format
+```
+
+Then re-run build/tests if code was changed.
+
+---
+
+## Project Structure
+
+This is a C# .NET project — a game trainer mod for Software Inc. (Beta 1).
+
+- Solution file: `Trainer v5 - Beta 1.sln`
+- Source project: `Trainer_v5/Trainer_v5.csproj`
+- Source code: `Trainer_v5/Trainer.Source/`
+- Libraries: `Trainer_v5/Trainer.Libraries/`
+- Localization: `Trainer_v5/Trainer.Localization/`
+
+---
+
+## Repository Documentation
+
+Keep project documentation aligned with behavior, setup, commands, public features, and versioned output.
+
+- Update `README.md` when changing setup, build, run, or usage steps.
+- Update `CHANGELOG.md` when adding, changing, fixing, or removing user-facing features. Use newest version first. Do not dump raw git commits.
+- Update `FEATURES.md` when features are added, removed, or change state.
+- Do not invent features, claims, performance numbers, or compatibility guarantees.
+
+---
+
+## Artifact and Bundle Naming
+
+Use stable, searchable filenames for generated artifacts, bundles, and release packages.
+
+- Do not use vague suffixes such as `final`, `final2`, `new`, `latest`, `copy`, `fixed`, or `v2`.
+- Use `MAJOR.MINOR.PATCH` format.
+- Keep the artifact name prefix stable across versions.
+
+Pattern: `<artifact-name>_<major>.<minor>.<patch>.<extension>`
+
+---
+
+## Code Conventions
+
+Detailed code conventions live in separate files under `docs/`:
+
+- C#/.NET: `docs/coding-conventions-csharp.md`
+- Shell/Python scripts: `docs/coding-conventions-scripts.md`
+
+Rules:
+
+- Follow the nearest applicable convention file for the files being edited.
+- Preserve existing local style when it conflicts with a generic convention and the task is not style cleanup.
+- Preserve existing indentation style: tabs in this repo for C# files.
+- Do not rewrite unrelated code just to satisfy conventions.
+
+---
+
+## Git Workflow
+
+This repository uses a simplified Git Flow. The long-lived branches are:
+
+- `main` — production branch (releases merged here)
+- `develop` — integration branch (feature work targets here)
+
+### Task Branches
+
+Create a new branch for work whenever the environment allows it. Never commit directly to `main` or `develop`.
+
+Branch naming:
+
+```text
+feature/<short-description>
+bugfix/<short-description>
+release/<version>
+hotfix/<short-description>
+chore/<short-description>
+docs/<short-description>
+```
+
+Branch source rules:
+
+- `feature/*`, `bugfix/*`, `chore/*`, and `docs/*` branch from `develop`.
+- `release/*` branches from `develop`.
+- `hotfix/*` branches from `main`.
+
+Use lowercase kebab-case for branch descriptions.
+
+### No AI Names in Git Artifacts
+
+Do not include AI assistant, tool, provider, or model names in branch names, commit messages, PR titles, PR descriptions, review comments, changelog entries, release notes, or generated helper text.
+
+Write Git artifacts as if authored by the repository maintainer.
+
+Allowed exception: files whose purpose is AI-agent configuration or documentation, such as `AGENTS.md` and `CLAUDE.md`.
+
+### Pull Request Rules
+
+- Create or propose a pull request for completed work.
+- Do not auto-merge pull requests.
+- Do not approve your own pull request.
+- Do not bypass branch protection.
+
+Default PR targets:
+
+- `feature/*`, `bugfix/*`, `chore/*`, and `docs/*` target `develop`.
+- `release/*` targets `main`.
+- `hotfix/*` targets `main`, then must also be brought back to `dev`.
+
+### Commit Rules
+
+- Keep commits focused and logically grouped.
+- Use imperative commit messages.
+- Do not include secrets, credentials, tokens, local paths, machine-specific files, or AI assistant/model/tool names.
+
+Examples:
+
+```text
+Add order export validation
+Fix enum mapping for payment status
+Update agent guidelines
+```
+
+---
+
+## Command Safety
+
+Do not run destructive commands unless explicitly instructed.
+
+Examples of destructive commands:
+
+```bash
+git reset --hard
+git clean -fd
+git push --force
+git branch -D <branch>
+rm -rf <path>
+```
+
+If a destructive action seems necessary, explain the reason and ask first.
+
+---
+
+## Boundaries
+
+Do not modify without explicit instruction:
+
+- secrets, credentials, tokens, certificates, or `.env*` files
+- production deployment files
+- CI/CD pipelines
+- generated code
+- lock files
+- package references or dependency versions
+- public API contracts
+- authentication/authorization behavior
+
+Do not commit secrets or machine-specific files.
+
+---
+
+## Dependency Policy
+
+- Do not add production dependencies unless explicitly required by the task.
+- Prefer built-in language/framework APIs before adding packages.
+- If a dependency is necessary, choose a maintained package and explain why.
+- Do not change package versions as part of unrelated work.
+
+---
+
+## Agent Completion Checklist
+
+Before finishing a task, confirm:
+
+- Applicable convention docs under `docs/` were checked for changed code/scripts/docs.
+- Existing indentation style was preserved in modified files (tabs for C#).
+- Existing user-facing text/output style was preserved, including ASCII vs Unicode punctuation and decorative separators.
+- C# control-flow spacing was preserved or applied: blank line after a completed control block before the next independent statement.
+- A new task branch was created, or branch creation was impossible and the reason is reported.
+- Changes are focused on the requested task.
+- New behavior has unit tests when feasible, or a clear explanation why tests were not added.
+- The affected project was built when possible, or skipped with a clear reason.
+- Relevant automated tests were run when available, or skipped with a clear reason.
+- The implementation was rechecked against requirements and changed files.
+- `README.md`, `CHANGELOG.md`, or `FEATURES.md` were updated when the change affected public behavior, setup, commands, or features.
+- A pull request was created, or exact PR instructions were provided.
+- Branch names, commit messages, PR text, changelog entries, and helper text do not contain AI assistant/model/tool names.
+- The PR was not auto-merged.
+
+---
+
+## PR Description Template
+
+Use `.github/pull_request_template.md` when it exists. Otherwise, use this structure:
+
+```markdown
+## Summary
+- 
+
+## Changes
+- 
+
+## Documentation
+- [ ] README.md updated if needed
+- [ ] CHANGELOG.md updated if needed
+- [ ] FEATURES.md updated if needed
+
+## Validation
+- [ ] `dotnet format --verify-no-changes`
+- [ ] `dotnet build`
+- [ ] `dotnet test`
+- [ ] Smoke/manual check where practical
+- [ ] Implementation rechecked against requirements
+
+## Notes / Risks
+- 
+```
+
+---
+
+## Updating This File
+
+Update `AGENTS.md` when:
+
+- project structure changes
+- build/test/lint commands change
+- recurring agent mistakes are discovered
+- new architectural boundaries are introduced
+
+Keep updates short, operational, and specific. Detailed style rules belong in separate files under `docs/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# CLAUDE.md
+
+@AGENTS.md
+
+## Claude Code
+
+Use the imported `AGENTS.md` as the primary project instruction file.
+
+Do not duplicate rules here unless they are specific to Claude Code behavior or local Claude Code setup.

--- a/docs/coding-conventions-csharp.md
+++ b/docs/coding-conventions-csharp.md
@@ -1,0 +1,421 @@
+# C# / .NET Coding Conventions
+
+Detailed C#/.NET conventions for repositories that use this agent guideline pack.
+
+**Version**: 1.17  
+**Status**: Active  
+**Last Updated**: 2026-06-18
+
+Use repository-specific conventions first. If the target repository or child `AGENTS.md` defines different C# rules, follow the nearest applicable project rule.
+
+---
+
+## Quick Reference
+
+| Area | Rule |
+|------|------|
+| Usings | `System` first, remaining directives alphabetized, no blank lines |
+| Namespace | File-scoped namespace preferred |
+| Indentation | Preserve existing file/repo style; default to tabs for new `*.cs` files only when no local style exists |
+| Constants | `PascalCase`, placed before fields |
+| Private fields | `_camelCase` |
+| Properties | `PascalCase` |
+| Interfaces | `I` prefix |
+| Enums | Project-specific `Enum` suffix, real values start at `1` |
+| Async methods | `Async` suffix for `Task`, `Task<T>`, `ValueTask`, `ValueTask<T>` |
+| Control flow | Always use braces; no inline `if (...) return/throw/break/continue` statements; add a blank line after completed control blocks before independent statements |
+| User-facing text | Preserve existing ASCII/Unicode punctuation and decorative separator style |
+| Member order | Constants → Fields → Properties → Events → Constructor → Expression-bodied → Public → Protected → Protected event raisers → Private |
+
+---
+
+## Using Directives
+
+Rules:
+
+- Place all `using` directives at the top of the file, before the namespace.
+- Use Visual Studio **Remove and Sort Usings** (`Ctrl+R, Ctrl+G`) as the default cleanup behavior.
+- Place `System` namespace directives first.
+- Alphabetize all remaining using directives.
+- Do not manually separate framework, NuGet, and local project namespaces unless a specific project requires it.
+- Do not add blank lines between using directives.
+- Remove unused using directives.
+
+Correct pattern:
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using MyCompany.Sales.Models;
+using MyCompany.Sales.Services;
+
+namespace MyCompany.Sales.OrderManagement;
+```
+
+---
+
+## Indentation
+
+Preserve the existing indentation style of the file or repository.
+
+Rules:
+
+- If the existing C# file uses spaces, continue using spaces.
+- If the existing C# file uses tabs, continue using tabs.
+- Do not convert a file from spaces to tabs or tabs to spaces unless the task explicitly asks for formatting/style cleanup.
+- For new C# files in repositories without an established style, prefer tabs with width 4.
+- Follow the nearest `.editorconfig` when one exists.
+- Do not force C# indentation preferences onto Markdown, JSON, YAML, XML, project files, or generated files.
+
+---
+
+## Naming
+
+- Public members, types, namespaces, constants, and properties: `PascalCase`.
+- Private fields: `_camelCase`.
+- Parameters and local variables: `camelCase`.
+- Interfaces: `I` prefix, e.g. `IOrderService`.
+- Type parameters: `T` prefix, e.g. `TEntity`, `TInput`.
+- Async methods returning `Task`, `Task<T>`, `ValueTask`, or `ValueTask<T>` must use the `Async` suffix.
+- Boolean properties should start with `Is`, `Has`, `Can`, or `Should` where natural.
+- Avoid Hungarian notation.
+- Avoid abbreviations unless they are widely understood.
+- Avoid single-letter names except loop counters and very small lambda scopes.
+
+---
+
+## Enums
+
+Project-specific rule: enum type names must use the `Enum` suffix.
+
+Enum values must start from `1`. Value `0` is reserved only for special fallback values such as `Unknown`, `Unspecified`, or `None` for flags.
+
+Correct pattern:
+
+```csharp
+public enum OrderStatusEnum
+{
+	Unknown = 0,
+	Pending = 1,
+	Processing = 2,
+	Shipped = 3,
+	Delivered = 4,
+	Cancelled = 5
+}
+```
+
+Flags enum exception:
+
+```csharp
+[Flags]
+public enum FilePermissionsEnum
+{
+	None = 0,
+	Read = 1,
+	Write = 2,
+	Execute = 4,
+	Delete = 8
+}
+```
+
+---
+
+## Member Organization
+
+Use this order inside classes:
+
+```text
+Constants
+Fields
+Properties
+Events
+Constructor
+Expression-bodied members
+Public methods
+Protected methods
+Protected event raisers
+Private methods
+```
+
+Rules:
+
+- Constants go before fields.
+- Constructors come after constants, fields, properties, and events.
+- Expression-bodied members go after constructors and before normal methods.
+- Public API should be easy to scan.
+- Private implementation details belong near the bottom.
+- Keep related members together when readability clearly improves.
+
+Example:
+
+```csharp
+public class Order
+{
+	public const int MaxRetries = 3;
+
+	private readonly IOrderRepository _orderRepository;
+	private bool _isProcessed;
+
+	public int OrderId { get; set; }
+	public string CustomerName { get; set; }
+	public bool IsActive { get; set; }
+
+	public event EventHandler<OrderEventArgs>? OrderStatusChanged;
+
+	public Order(IOrderRepository orderRepository, int orderId, string customerName)
+	{
+		_orderRepository = orderRepository ?? throw new ArgumentNullException(nameof(orderRepository));
+		OrderId = orderId;
+		CustomerName = customerName;
+		_isProcessed = false;
+	}
+
+	public bool IsReady => IsActive && OrderId > 0;
+
+	public void Process()
+	{
+		if (!IsReady)
+		{
+			return;
+		}
+
+		_isProcessed = true;
+	}
+
+	protected virtual void OnOrderStatusChanged(OrderEventArgs e)
+	{
+		OrderStatusChanged?.Invoke(this, e);
+	}
+
+	private bool Validate()
+	{
+		return OrderId > 0;
+	}
+}
+```
+
+---
+
+## Properties, Fields, and Constants
+
+Properties:
+
+- Use PascalCase.
+- Group properties by type when it improves readability.
+- Do not add blank lines between consecutive properties of the same type unless attributes are present.
+- Separate attributed properties with blank lines.
+
+Fields:
+
+- Private fields use `_camelCase`.
+- Prefer `readonly` when the value should not change after construction.
+- Avoid public fields; use properties instead.
+- Group fields by type and access level.
+- Do not add blank lines between consecutive fields of the same type unless attributes are present.
+
+Constants:
+
+- Use PascalCase.
+- Use `const` for compile-time constants.
+- Use `static readonly` for runtime constants.
+- Avoid public constants unless they are intentionally part of the public API.
+
+---
+
+## Control Flow and Spacing
+
+Always use braces for `if`, `else if`, and `else`, even for single-line statements.
+
+Do not place control-flow actions inline after a condition. Put `return`, `throw`, `break`, `continue`, and similar statements inside the block on their own line.
+
+Correct:
+
+```csharp
+if (order == null)
+{
+	throw new ArgumentNullException(nameof(order));
+}
+
+if (task.Category != TaskCategoryEnum.Training)
+{
+	return true;
+}
+```
+
+Incorrect:
+
+```csharp
+if (order == null)
+	throw new ArgumentNullException(nameof(order));
+
+if (task.Category != TaskCategoryEnum.Training) return true;
+```
+
+Spacing rules are preferred readability guidelines, not hard blockers.
+
+Preferred style:
+
+- Single variable followed by a simple guard `if`: no blank line.
+- Multiple variables followed by an `if`: add a blank line before the `if`.
+- `if/else` or `if/else if/else` blocks: add a blank line before the block.
+- After a completed control block, add a blank line before the next independent statement.
+- Do not add a blank line between `}` and a directly connected `else`, `catch`, `finally`, or `while` in a `do/while` block.
+- When in doubt, optimize for readability and consistency with nearby code.
+
+Correct spacing after a completed control block:
+
+```csharp
+if (!allowed)
+{
+	EventBus.Publish(new OnTerminalMessage(
+		reason,
+		TerminalPrefixEnum.Warn,
+		TerminalCategoryEnum.Locked));
+}
+
+return allowed;
+```
+
+Incorrect spacing after a completed control block:
+
+```csharp
+if (!allowed)
+{
+	EventBus.Publish(new OnTerminalMessage(
+		reason,
+		TerminalPrefixEnum.Warn,
+		TerminalCategoryEnum.Locked));
+}
+return allowed;
+```
+
+---
+
+## Modern C# Defaults
+
+Use modern C# features when they improve clarity. Do not rewrite working code only to use newer syntax.
+
+Defaults:
+
+- Prefer file-scoped namespaces.
+- Use `var` when the type is obvious from the right-hand side.
+- Use explicit types when they improve readability.
+- Prefer records for immutable DTOs and value-like models.
+- Prefer collection expressions where they are readable and supported by the target language version.
+- Prefer pattern matching when it reduces branching or improves clarity.
+- Use primary constructors only for simple classes where they improve readability.
+- Avoid primary constructors in complex services with validation, many dependencies, or non-trivial initialization.
+- Use `required` properties only when they improve object initialization safety.
+- Avoid `#region` in normal application code; if a class needs regions, it is probably too large.
+- Regions are acceptable in generated, interop, designer, or legacy code when they reduce noise.
+- Do not introduce nullable reference type migrations unless the task explicitly asks for it.
+
+---
+
+## User-Facing Text and Output Style
+
+Preserve the existing style of user-facing strings, terminal output, logs intended for humans, menu labels, headings, prompts, and UI text.
+
+Rules:
+
+- Do not mix plain ASCII separators with Unicode/box-drawing separators in the same output area.
+- If nearby output uses plain ASCII dashes, keep using plain ASCII dashes.
+- If nearby output uses Unicode box-drawing characters or em/en dashes, keep using that style consistently.
+- Do not replace simple text with decorative Unicode, emoji, or box-drawing characters unless the task asks for that style.
+- Do not downgrade existing intentional Unicode formatting to ASCII unless the project prefers ASCII-only output.
+- When adding a new terminal/UI section, copy the style of the closest existing section.
+
+Correct when the surrounding output uses plain ASCII:
+
+```csharp
+_terminal.AppendLine("-- Training & Capabilities --", TerminalPrefixEnum.Sys);
+_terminal.AppendLine("-- Inventory --", TerminalPrefixEnum.Sys);
+```
+
+Correct when the surrounding output uses Unicode separators:
+
+```csharp
+_terminal.AppendLine("── Training & Capabilities ──────────────────────────", TerminalPrefixEnum.Sys);
+_terminal.AppendLine("── Inventory ────────────────────────────────────────", TerminalPrefixEnum.Sys);
+```
+
+Incorrect mixed style:
+
+```csharp
+_terminal.AppendLine("── Training & Capabilities ──────────────────────────", TerminalPrefixEnum.Sys);
+_terminal.AppendLine("-- Inventory --", TerminalPrefixEnum.Sys);
+```
+
+---
+
+## Error Handling and Logging
+
+- Validate public method inputs where invalid values would create unclear failures.
+- Throw specific exceptions where appropriate.
+- Do not swallow exceptions silently.
+- Preserve stack traces; use `throw;`, not `throw ex;`.
+- Use structured logging placeholders instead of string interpolation in logger calls.
+
+Preferred logging pattern:
+
+```csharp
+_logger.LogInformation("Order {OrderId} created successfully.", order.Id);
+```
+
+---
+
+## Tests
+
+- Add or update tests for behavior changes.
+- Add unit tests when feasible for new logic, bug fixes, validation rules, mapping logic, parsing/formatting logic, and edge cases.
+- Prefer focused unit tests for business logic.
+- Prefer integration tests for persistence, API, and cross-component behavior.
+- Keep tests deterministic.
+- Do not add brittle tests that depend on timing, test execution order, external services, or local machine state.
+- Do not remove tests unless they are obsolete and the reason is clear.
+- If a test is flaky, report it instead of hiding it.
+- If tests are not added for a code change, explain why in the completion summary or PR notes.
+
+---
+
+## `.editorconfig` Baseline
+
+Use `.editorconfig` as the source of truth for formatting rules in repositories that adopt it. For existing repositories, preserve the local indentation style before adopting or changing `.editorconfig`; if the repo already uses spaces for C#, change the example before formatting.
+
+```editorconfig
+root = true
+
+[*.cs]
+# Default for new C# files when no local style already exists.
+# Existing files should preserve their current indentation style.
+indent_style = tab
+indent_size = 4
+tab_width = 4
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+csharp_style_namespace_declarations = file_scoped:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = false:suggestion
+csharp_style_var_for_built_in_types = false:suggestion
+
+[*.{md,json,yml,yaml,xml,csproj,sln}]
+indent_style = space
+indent_size = 2
+```
+
+---
+
+## StyleCop Compatibility
+
+If StyleCop is used, configure it to match this document instead of accepting conflicting defaults.
+
+Important alignment points:
+
+- Using directives should remain outside the namespace.
+- File-scoped namespaces should be allowed.
+- `System` directives should be sorted first.
+- Blank lines between using directive groups should not be required.

--- a/docs/coding-conventions-scripts.md
+++ b/docs/coding-conventions-scripts.md
@@ -1,0 +1,224 @@
+# Shell and Python Script Conventions
+
+Detailed conventions for standalone shell and Python scripts.
+
+**Version**: 1.16  
+**Status**: Active  
+**Last Updated**: 2026-06-15
+
+Use repository-specific script conventions first. If the target repository or child `AGENTS.md` defines different rules, follow the nearest applicable project rule.
+
+---
+
+## Scope
+
+These rules apply to standalone utility scripts such as:
+
+- `.sh`
+- `.bash`
+- `.py`
+- one-off automation scripts that are versioned as files
+- scripts that generate local output files
+
+If a script is part of a package/application with its own packaging/versioning system, follow the repository standard and keep script-specific versions consistent with it.
+
+---
+
+## Indentation Preservation
+
+Preserve the existing indentation style of the script being edited.
+
+Rules:
+
+- If the existing script uses spaces, continue using spaces.
+- If the existing script uses tabs, continue using tabs.
+- Do not convert indentation style unless the task explicitly asks for formatting/style cleanup.
+- For new Python scripts, use 4 spaces.
+- For new shell scripts, follow the nearest repository convention; tabs are acceptable for indentation when no local style exists.
+
+---
+
+## Filename and Versioning Rules
+
+For standalone shell or Python scripts, keep script filenames and script-generated output filenames stable and versioned.
+
+Rules:
+
+- Use the same script-name prefix for every version of the same script.
+- Put the version suffix immediately before the file extension.
+- Use semantic versioning in `MAJOR.MINOR.PATCH` format.
+- Do not use vague suffixes such as `final`, `final2`, `new`, `latest`, `copy`, `fixed`, `v2`, or date-only versions.
+- Keep the script extension unchanged: `.sh`, `.bash`, `.py`, etc.
+- When the script has an internal version constant, keep it aligned with the filename version.
+- Script-generated output files must use the same `<script-name>_<major>.<minor>.<patch>.<extension>` pattern unless the task or an existing project format requires a different output name.
+- If the output format needs a descriptive suffix, place it after the version and keep it stable.
+
+Filename pattern:
+
+```text
+<script-name>_<major>.<minor>.<patch>.<extension>
+```
+
+Output filename pattern:
+
+```text
+<script-name>_<major>.<minor>.<patch>.<extension>
+<script-name>_<major>.<minor>.<patch>_<stable-output-name>.<extension>
+```
+
+Examples:
+
+```text
+backup-photos_1.0.0.py
+backup-photos_1.0.1.py
+backup-photos_1.1.0.py
+cleanup-downloads_2.0.0.sh
+backup-photos_1.1.0.csv
+backup-photos_1.1.0_report.txt
+cleanup-downloads_2.0.0_log.txt
+```
+
+Version meaning:
+
+- `MAJOR`: breaking CLI, behavior, output format, config format, or compatibility change.
+- `MINOR`: backwards-compatible feature or option.
+- `PATCH`: bug fix, small internal improvement, comments, or non-breaking cleanup.
+
+---
+
+## Script Behavior
+
+- Prefer explicit CLI arguments over hardcoded local paths.
+- Provide `--help` or clear usage text when practical.
+- Validate inputs before destructive or expensive operations.
+- Print useful progress/error messages.
+- Exit with non-zero status on failure.
+- Avoid hidden network calls or destructive operations unless clearly documented and requested.
+- Do not embed secrets, tokens, passwords, or machine-specific paths.
+- Prefer dry-run support for scripts that move, delete, rename, upload, or modify many files.
+
+---
+
+## Python Script Defaults
+
+- Use 4 spaces for new Python scripts when no local style exists. Preserve existing indentation style when editing existing Python files.
+- Use readable, standard-library-first Python unless a dependency is clearly justified.
+- Prefer `argparse` for CLI arguments.
+- Use `pathlib` for filesystem paths.
+- Use functions instead of one long top-level script.
+- Use `if __name__ == "__main__":` for executable scripts.
+- Keep side effects out of import time.
+- Prefer clear exceptions and user-facing error messages.
+- Add tests for parsing, transformations, validation, and edge cases when feasible.
+
+Minimal structure:
+
+```python
+from pathlib import Path
+
+VERSION = "1.0.0"
+
+
+def main() -> int:
+    # implementation
+    return 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())
+```
+
+---
+
+## Shell Script Defaults
+
+- Preserve existing shell-script indentation style when editing existing files.
+- Prefer POSIX-compatible `sh` unless Bash-specific features are useful and documented.
+- Use a shebang appropriate to the script.
+- Use `set -euo pipefail` for Bash scripts when compatible with the script logic.
+- Quote variables unless word splitting is explicitly intended.
+- Validate required commands and input paths.
+- Avoid destructive commands without confirmation or dry-run support.
+- Print clear errors to stderr.
+
+Bash starter:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="1.0.0"
+
+main() {
+	# implementation
+	return 0
+}
+
+main "$@"
+```
+
+---
+
+## CLI Output Text Style
+
+Preserve the existing CLI/user-facing output style of the script.
+
+Rules:
+
+- Do not mix plain ASCII separators with Unicode/box-drawing separators in the same output area.
+- If the script already uses ASCII-only output, keep new output ASCII-only unless asked otherwise.
+- If the script intentionally uses Unicode symbols, headings, or separators, keep additions consistent with that style.
+- Do not add emoji, decorative Unicode, colors, or box-drawing output unless the script already uses them or the task asks for them.
+- Copy the style of nearby headings, prompts, status messages, and error messages.
+
+Examples:
+
+```text
+-- Backup Summary --
+-- Errors --
+```
+
+```text
+── Backup Summary ───────────────────────────────────
+── Errors ────────────────────────────────────────────
+```
+
+Do not mix both styles in the same script output.
+
+---
+
+## Output Files
+
+When a script writes output files:
+
+- Use stable, predictable filenames.
+- Include the script version in generated filenames unless an existing project format requires otherwise.
+- Do not overwrite existing output files silently unless the script clearly documents that behavior.
+- Prefer writing to an explicit output directory or explicit output file path.
+- For logs/reports, use stable suffixes like `_report`, `_log`, `_errors`, `_summary`.
+
+Examples:
+
+```text
+backup-photos_1.1.0_report.txt
+backup-photos_1.1.0_errors.csv
+cleanup-downloads_2.0.0_log.txt
+```
+
+---
+
+## Validation
+
+When practical, run:
+
+```bash
+python script-name_1.0.0.py --help
+./script-name_1.0.0.sh --help
+```
+
+For scripts with behavior changes:
+
+- run a small smoke test
+- use a temporary directory or sample input
+- avoid modifying real user data during validation
+- report exactly what was tested and what was skipped


### PR DESCRIPTION
## Summary
- Installs agent-guidelines-pack v1.17.0 into the repository

## Changes
- `AGENTS.md` — AI agent operational rules, adapted for this repo (`develop` branch, C#/.NET project structure)
- `CLAUDE.md` — Claude Code wrapper that imports `AGENTS.md`
- `.editorconfig` — formatting baseline (tabs/4 for C#, matching existing codebase)
- `.github/pull_request_template.md` — PR checklist with `dotnet` validation steps
- `docs/coding-conventions-csharp.md` — C#/.NET conventions
- `docs/coding-conventions-scripts.md` — shell/Python script conventions

## Documentation
- [x] `AGENTS.md` documents project structure, branching, and validation commands
- [ ] `README.md` — covered in follow-up PR #53
- [ ] `CHANGELOG.md` — tooling/process addition, not a user-facing feature change

## Validation
- [ ] `dotnet format --verify-no-changes`
- [ ] `dotnet build`
- [ ] `dotnet test`
- [x] Docs and tooling files only — no production code changed

## Notes / Risks
- No production code modified
- `.editorconfig` `indent_style = tab` for `*.cs` matches the existing codebase style
- Merge this before PR #53 so the README can reference the conventions that exist

---
_Generated by [Claude Code](https://claude.ai/code/session_0122oXgcAzNJXaiamebZFPaA)_