### PR TITLE
Add stable release on main push and nightly develop build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,30 +1,45 @@
-name: Release
+name: Nightly
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - 'v*.*.*'
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
 
 jobs:
-  build:
-    name: Build and publish
+  nightly:
+    name: Nightly build
     runs-on: windows-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
+
+      - name: Check for commits in the last 24 hours
+        id: check
+        shell: pwsh
+        run: |
+          $commits = git log --since="24 hours ago" --oneline
+          if ($commits) {
+            echo "has_commits=true" >> $env:GITHUB_OUTPUT
+          } else {
+            echo "has_commits=false" >> $env:GITHUB_OUTPUT
+          }
 
       - name: Setup .NET
+        if: steps.check.outputs.has_commits == 'true'
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.x'
 
       - name: Build (Release)
+        if: steps.check.outputs.has_commits == 'true'
         run: dotnet build "Trainer v5 - Beta 1.sln" --configuration Release --no-incremental
 
       - name: Stage release files
+        if: steps.check.outputs.has_commits == 'true'
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Path release | Out-Null
@@ -32,31 +47,25 @@ jobs:
           Copy-Item -Recurse Trainer_v5/Trainer.Localization release/Trainer.Localization
 
       - name: Package
+        if: steps.check.outputs.has_commits == 'true'
         shell: pwsh
         run: Compress-Archive -Path release/* -DestinationPath Trainer_v5.zip
 
       - name: Upload artifact
+        if: steps.check.outputs.has_commits == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: Trainer_v5
+          name: Trainer_v5_nightly
           path: Trainer_v5.zip
           if-no-files-found: error
 
-      - name: Create stable release
-        if: github.ref == 'refs/heads/main'
+      - name: Create nightly release
+        if: steps.check.outputs.has_commits == 'true'
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: latest
-          name: Latest Stable
+          tag_name: nightly
+          name: Nightly
           files: Trainer_v5.zip
           draft: false
-          prerelease: false
-          generate_release_notes: false
-
-      - name: Create versioned release
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
-        with:
-          files: Trainer_v5.zip
-          draft: true
+          prerelease: true
           generate_release_notes: false


### PR DESCRIPTION
## Summary
- Every push to `main` now creates/updates a `latest` stable release automatically
- New nightly workflow builds `develop` at 2am UTC and publishes a `nightly` pre-release, but only when there are commits in the last 24 hours

## Changes
- `release.yml`: split the release step into two — stable (`latest` tag, non-draft) on branch push, versioned (draft) on tag push
- `nightly.yml`: new workflow on cron schedule; skips all steps if develop has no recent commits

## Documentation
- [ ] README.md updated if needed
- [ ] CHANGELOG.md updated if needed
- [ ] FEATURES.md updated if needed

## Validation
- [ ] `dotnet format --verify-no-changes`
- [ ] `dotnet build`
- [ ] `dotnet test`
- [ ] Smoke/manual check where practical
- [ ] Implementation rechecked against requirements

## Branching / Merge Safety
- [x] Branch follows `feature/*`
- [x] PR targets `develop`
- [ ] No auto-merge requested/performed

## Notes / Risks
- The `latest` and `nightly` tags are force-updated on each run by `softprops/action-gh-release@v2`; this is expected behavior for rolling release tags
- Nightly requires `fetch-depth: 0` to have full git history for the `--since` check

---
_Generated by [Claude Code](https://claude.ai/code/session_01GegTaA2AiZXdDW3NRT3E3y)_