### PR TITLE
Generate versioned releases from trainer version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,9 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'v*.*.*'
+
+permissions:
+  contents: write
 
 jobs:
   build:
@@ -15,14 +16,46 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.x'
 
+      - name: Read release version
+        id: version
+        shell: pwsh
+        run: |
+          $content = Get-Content -Raw "Trainer_v5/Trainer.Source/Helpers.cs"
+          $match = [regex]::Match(
+            $content,
+            'public\s+static\s+string\s+Version\s*=>\s*"(?<version>\d+\.\d+\.\d+)";'
+          )
+
+          if (-not $match.Success) {
+            throw "Could not read a semantic version from Helpers.Version."
+          }
+
+          $version = $match.Groups["version"].Value
+          $tag = "v$version"
+          $existingTag = git tag --list $tag
+
+          if ($existingTag) {
+            $tagCommit = git rev-list -n 1 $tag
+            $currentCommit = git rev-parse HEAD
+
+            if ($tagCommit -ne $currentCommit) {
+              throw "Tag $tag already points to another commit. Increase Helpers.Version before releasing."
+            }
+          }
+
+          "version=$version" >> $env:GITHUB_OUTPUT
+          "tag=$tag" >> $env:GITHUB_OUTPUT
+
       - name: Build (Release)
-        run: dotnet build "Trainer v5 - Beta 1.sln" --configuration Release --no-incremental
+        run: dotnet build "Trainer v5 - Beta 1.sln" --configuration Release --no-incremental --property:Version=${{ steps.version.outputs.version }}
 
       - name: Stage release files
         shell: pwsh
@@ -33,30 +66,23 @@ jobs:
 
       - name: Package
         shell: pwsh
-        run: Compress-Archive -Path release/* -DestinationPath Trainer_v5.zip
+        run: Compress-Archive -Path release/* -DestinationPath Trainer_v5_${{ steps.version.outputs.version }}.zip
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: Trainer_v5
-          path: Trainer_v5.zip
+          name: Trainer_v5_${{ steps.version.outputs.version }}
+          path: Trainer_v5_${{ steps.version.outputs.version }}.zip
           if-no-files-found: error
 
-      - name: Create stable release
-        if: github.ref == 'refs/heads/main'
+      - name: Create versioned release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: latest
-          name: Latest Stable
-          files: Trainer_v5.zip
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: Trainer v${{ steps.version.outputs.version }}
+          target_commitish: ${{ github.sha }}
+          files: Trainer_v5_${{ steps.version.outputs.version }}.zip
           draft: false
           prerelease: false
           generate_release_notes: false
-
-      - name: Create versioned release
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
-        with:
-          files: Trainer_v5.zip
-          draft: true
-          generate_release_notes: false
+          make_latest: true

--- a/README.md
+++ b/README.md
@@ -35,5 +35,6 @@ See [`AGENTS.md`](AGENTS.md) for full branching rules and coding conventions.
 | Trigger | Workflow | Result |
 |---------|----------|--------|
 | Push or PR to `develop` | CI | Build check |
-| Push to `main` | Release | Build + zip artifact |
-| Tag `v*.*.*` on `main` | Release | Build + zip artifact + draft GitHub Release |
+| Push to `main` | Release | Build + versioned zip artifact + versioned GitHub Release |
+
+The release workflow reads the semantic version from `Helpers.Version`. A release creates the matching `v<major>.<minor>.<patch>` tag and uses the version in the downloadable archive name. Increase `Helpers.Version` before merging another release to `main`.


### PR DESCRIPTION
## Summary
- Generate stable release metadata from `Helpers.Version` when changes reach `main`.

## Changes
- Validate the trainer version as `MAJOR.MINOR.PATCH`.
- Apply the version to the Release build, archive, artifact, tag, and GitHub Release.
- Reject reuse of a version tag that points to another commit.
- Mark the generated versioned release as the latest release.

## Documentation
- [x] README.md updated if needed
- [ ] CHANGELOG.md updated if needed
- [ ] FEATURES.md updated if needed

## Validation
- [ ] `dotnet format --verify-no-changes`
- [x] `dotnet build`
- [x] `dotnet test`
- [x] Smoke/manual check where practical
- [x] Implementation rechecked against requirements

Release build completed with three existing compiler warnings and no errors. The generated DLL reports assembly version `5.2.6.0`. The version extraction returned `5.2.6`. The solution contains no test projects producing test output. Workflow lint was not run because `actionlint` is not installed locally.

## Branching / Merge Safety
- [x] Branch follows `feature/*`, `release/*`, or `hotfix/*`
- [x] PR targets the correct Git Flow branch
- [x] No auto-merge requested/performed

## Notes / Risks
- A later release from `main` must increase `Helpers.Version` after its version tag has been created.