### PR TITLE
Add RC versions to nightly releases

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   nightly:
     name: Nightly build
@@ -28,6 +31,31 @@ jobs:
             echo "has_commits=false" >> $env:GITHUB_OUTPUT
           }
 
+      - name: Read nightly version
+        if: steps.check.outputs.has_commits == 'true'
+        id: version
+        shell: pwsh
+        env:
+          RC_NUMBER: ${{ github.run_number }}
+        run: |
+          $content = Get-Content -Raw "Trainer_v5/Trainer.Source/Helpers.cs"
+          $match = [regex]::Match(
+            $content,
+            'public\s+static\s+string\s+Version\s*=>\s*"(?<version>\d+\.\d+\.\d+)";'
+          )
+
+          if (-not $match.Success) {
+            throw "Could not read a semantic version from Helpers.Version."
+          }
+
+          $baseVersion = $match.Groups["version"].Value
+          $version = "$baseVersion-rc$env:RC_NUMBER"
+          $commit = git rev-parse HEAD
+
+          "version=$version" >> $env:GITHUB_OUTPUT
+          "tag=v$version" >> $env:GITHUB_OUTPUT
+          "commit=$commit" >> $env:GITHUB_OUTPUT
+
       - name: Setup .NET
         if: steps.check.outputs.has_commits == 'true'
         uses: actions/setup-dotnet@v4
@@ -36,7 +64,7 @@ jobs:
 
       - name: Build (Release)
         if: steps.check.outputs.has_commits == 'true'
-        run: dotnet build "Trainer v5 - Beta 1.sln" --configuration Release --no-incremental
+        run: dotnet build "Trainer v5 - Beta 1.sln" --configuration Release --no-incremental --property:Version=${{ steps.version.outputs.version }}
 
       - name: Stage release files
         if: steps.check.outputs.has_commits == 'true'
@@ -49,23 +77,25 @@ jobs:
       - name: Package
         if: steps.check.outputs.has_commits == 'true'
         shell: pwsh
-        run: Compress-Archive -Path release/* -DestinationPath Trainer_v5.zip
+        run: Compress-Archive -Path release/* -DestinationPath Trainer_v5_${{ steps.version.outputs.version }}.zip
 
       - name: Upload artifact
         if: steps.check.outputs.has_commits == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: Trainer_v5_nightly
-          path: Trainer_v5.zip
+          name: Trainer_v5_${{ steps.version.outputs.version }}
+          path: Trainer_v5_${{ steps.version.outputs.version }}.zip
           if-no-files-found: error
 
       - name: Create nightly release
         if: steps.check.outputs.has_commits == 'true'
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: nightly
-          name: Nightly
-          files: Trainer_v5.zip
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: Trainer v${{ steps.version.outputs.version }}
+          target_commitish: ${{ steps.version.outputs.commit }}
+          files: Trainer_v5_${{ steps.version.outputs.version }}.zip
           draft: false
           prerelease: true
           generate_release_notes: false
+          make_latest: false

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ See [`AGENTS.md`](AGENTS.md) for full branching rules and coding conventions.
 | Trigger | Workflow | Result |
 |---------|----------|--------|
 | Push or PR to `develop` | CI | Build check |
+| Daily schedule or manual dispatch | Nightly | Build + versioned RC artifact + prerelease |
 | Push to `main` | Release | Build + versioned zip artifact + versioned GitHub Release |
 
 The release workflow reads the semantic version from `Helpers.Version`. A release creates the matching `v<major>.<minor>.<patch>` tag and uses the version in the downloadable archive name. Increase `Helpers.Version` before merging another release to `main`.
+
+The nightly workflow appends the workflow run number as an RC suffix, producing versions such as `5.2.6-rc123`. Nightly prereleases do not replace the latest stable release.


### PR DESCRIPTION
## Summary
- Give each nightly build a version derived from `Helpers.Version` and the workflow run number.

## Changes
- Generate prerelease versions such as `5.2.6-rc123`.
- Apply the version to build metadata, archive and artifact names, Git tags, and GitHub prereleases.
- Target the checked-out `develop` commit and prevent nightly builds from replacing the latest stable release.

## Documentation
- [x] README.md updated if needed
- [ ] CHANGELOG.md updated if needed
- [ ] FEATURES.md updated if needed

## Validation
- [ ] `dotnet format --verify-no-changes`
- [x] `dotnet build`
- [x] `dotnet test`
- [x] Smoke/manual check where practical
- [x] Implementation rechecked against requirements

The Release build completed with three existing compiler warnings and no errors. Version extraction produced `5.2.6-rc123`; the compiled product metadata starts with that version. The solution contains no test projects producing test output. Workflow lint was not run because `actionlint` is not installed locally.

## Branching / Merge Safety
- [x] Branch follows `feature/*`, `release/*`, or `hotfix/*`
- [x] PR targets the correct Git Flow branch
- [x] No auto-merge requested/performed

## Notes / Risks
- RC numbers use GitHub's monotonically increasing workflow run number, so they do not restart when `Helpers.Version` changes.