### PR TITLE
Fix features missing from Release builds; simplify lead-spec setters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,277 +6,154 @@ documented in this file.
 Newest entries first. Dates use `YYYY-MM-DD`. Versions use the semantic version
 from `Helpers.Version`. All releases target *Software Inc.* Beta 1.
 
-## Unreleased
-
-### Changed
+## [5.2.7] - 2026-09-10
 
 - Documentation restructured to the managed templates (README, CHANGELOG, and
   the architecture overview).
-
-### Removed
-
-- Support for *Software Inc.* Beta 1.6: dropped the `SWINCBETA1_6` build
-  configuration and the 1.6-specific compatibility code paths. The trainer now
-  targets Beta 1.7 and newer.
+- Removed version-conditional compilation from the lead-specialization setters;
+  they now use a single code path.
 
 ## [5.2.6] - 2026-05-25
-
-### Added
 
 - Max Market Share button: instantly sets all company products to 100% market share.
 - Auto Max Market Share toggle: keeps all company products at 100% market share continuously.
 
 ## [5.2.5] - 2026-01-16
 
-### Changed
-
 - Updated libraries.
 
 ## [5.2.4] - 2025-10-08
 
-### Changed
-
 - Updated libraries.
-
-### Removed
-
-- Reduce Box Price, due to incompatibility.
+- Removed Reduce Box Price, due to incompatibility.
 
 ## [5.2.3] - 2025-08-24
-
-### Changed
 
 - Updated libraries.
 
 ## [5.2.2] - 2024-12-23
 
-### Fixed
-
-- Creativity modification in DetailWindowTrainer (muddxyii).
+- Fixed Creativity modification in DetailWindowTrainer (muddxyii).
 
 ## [5.2.1] - 2024-11-27
 
-### Changed
-
 - Updated libraries.
-
-### Fixed
-
-- Broken features.
+- Fixed broken features.
 
 ## [5.2.0] - 2024-11-08
 
-### Changed
-
 - Updated libraries.
-
-### Fixed
-
-- Broken features (muddxyii).
+- Fixed broken features (muddxyii).
 
 ## [5.1.9] - 2024-10-13
 
-### Changed
-
 - Updated libraries.
-
-### Fixed
-
-- Disable Stress toggle (savisitor15).
+- Fixed Disable Stress toggle (savisitor15).
 
 ## [5.1.8] - 2024-05-25
 
-### Added
-
 - Confirmation for the Max Reputation feature.
 - Experimental toggle.
-
-### Changed
-
 - Updated libraries.
 - UI logic refactor.
 
 ## [5.1.7] - 2023-10-23
 
-### Added
-
 - Experimental features column.
 - New loans.
-
-### Changed
-
 - Disable Employee smell (NoNeeds upgraded).
-
-### Fixed
-
 - Possible fix for NoSickness.
 - Possible fix for FreeEmployees where an employee tried to negotiate salary even when it was zero.
-
-### Removed
-
-- Deprecated features (non-fixable).
+- Removed deprecated features (non-fixable).
 
 ## [5.1.6] - 2023-10-22
 
-### Added
-
 - Auto Accept Hosting Deals feature.
-
-### Changed
-
 - Display game version in the Trainer Settings window.
 - Remove the distribution platform if the simulated company is bankrupt.
-
-### Fixed
-
-- Trainer Settings save on version increase.
-- Duplicated Hosting Deals when More Hosting Deals is activated.
-- Missing Hosting category when using the Max Reputation feature.
+- Fixed Trainer Settings save on version increase.
+- Fixed duplicated Hosting Deals when More Hosting Deals is activated.
+- Fixed missing Hosting category when using the Max Reputation feature.
 
 ## [5.1.5] - 2023-10-21
 
-### Fixed
-
-- Not saving new toggles.
+- Fixed not saving new toggles.
 
 ## [5.1.4] - 2023-10-16
 
-### Added
-
 - 8000% efficiency option.
 - Backward compatibility for Beta 1.6.
-
-### Changed
-
 - Trainer window: toggles rearranged.
 - Updated Discord invite link.
-
-### Fixed
-
-- Disable Fire Inspection feature.
+- Fixed Disable Fire Inspection feature.
 
 ## [5.1.3] - 2023-10-15
-
-### Added
 
 - Disable Fire Inspection feature.
 - Disable Force Pause feature.
 - Disable Force Freeze feature.
 - Auto Research Start feature.
 - Digital Distribution Monopol feature.
-
-### Changed
-
 - Dynamic loading of software types for More Hosting Deals.
 
 ## [5.1.2] - 2023-10-14
 
-### Added
-
 - Unlock and Claim all Rewards feature.
-
-### Changed
-
 - Updated libraries.
 
 ## [5.1.1] - 2023-09-11
 
-### Added
-
 - Added/updated localizations.
-
-### Fixed
-
-- Max Skill of employees feature.
+- Fixed Max Skill of employees feature.
 
 ## [5.1.0] - 2023-09-10
-
-### Changed
 
 - Updated libraries.
 
 ## [5.0.9] - 2023-05-20
 
-### Changed
-
 - Updated libraries.
-
-### Fixed
-
-- Compiler issues.
+- Fixed compiler issues.
 
 ## [5.0.8] - 2023-05-18
-
-### Changed
 
 - Updated libraries.
 
 ## [5.0.7] - 2023-04-15
 
-### Changed
-
 - Updated libraries.
 
 ## [5.0.6] - 2022-12-14
 
-### Added
-
 - Employee Demand change, Employee Lead Spec change, Employee Trait change, Console (credits: jiandy666).
 - Inspiration Use (credits: progesor).
-
-### Changed
-
 - Updated libraries.
 
 ## [5.0.5] - 2022-10-15
-
-### Changed
 
 - Updated libraries.
 
 ## [5.0.4] - 2022-09-17
 
-### Changed
-
 - Updated libraries.
-
-### Fixed
-
 - Typo fix.
 
 ## [5.0.3] - 2022-07-28
 
-### Changed
-
 - Updated libraries.
-
-### Removed
-
-- Auto Distribution Deals option, due to incompatibility.
+- Removed Auto Distribution Deals option, due to incompatibility.
 
 ## [5.0.2] - 2022-06-11
 
-### Changed
-
 - Updated libraries.
-
-### Fixed
-
 - Various fixes.
 
 ## [5.0.1] - 2022-04-02
 
-### Added
-
 - "Default" option for the efficiency dropdown(s).
 - New localizations: Croatian (Trawis), German (chaikobar), Korean (dragontalk), Spanish (jesustb).
-
-### Fixed
-
-- Lock Age option.
+- Fixed Lock Age option.
 
 ## [5.0] - 2022-03-14
-
-### Added
 
 - Initial version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ from `Helpers.Version`. All releases target *Software Inc.* Beta 1.
 - Documentation restructured to the managed templates (README, CHANGELOG, and
   the architecture overview).
 
+### Removed
+
+- Support for *Software Inc.* Beta 1.6: dropped the `SWINCBETA1_6` build
+  configuration and the 1.6-specific compatibility code paths. The trainer now
+  targets Beta 1.7 and newer.
+
 ## [5.2.6] - 2026-05-25
 
 ### Added
@@ -26,7 +32,7 @@ from `Helpers.Version`. All releases target *Software Inc.* Beta 1.
 
 - Updated libraries.
 
-## [5.2.5] - 2025-10-08
+## [5.2.4] - 2025-10-08
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ from `Helpers.Version`. All releases target *Software Inc.* Beta 1.
   the architecture overview).
 - Removed version-conditional compilation from the lead-specialization setters;
   they now use a single code path.
+- Fixed Digital Distribution Monopol and Auto Accept Hosting Deals being
+  compiled out of Release builds; they are now included in released binaries.
 
 ## [5.2.6] - 2026-05-25
 

--- a/Trainer_v5/Trainer.Source/Helpers.cs
+++ b/Trainer_v5/Trainer.Source/Helpers.cs
@@ -7,7 +7,7 @@ namespace Trainer_v5
 	public static class Helpers
 	{
 		public static bool IsGameLoaded => GameSettings.Instance != null && HUD.Instance != null;
-		public static string Version => "5.2.6";
+		public static string Version => "5.2.7";
 		public static string TrainerVersion => $"Trainer v{Version}";
 		public static bool IsDebug => false;
 		public static string DiscordUrl => "https://discord.com/invite/J584aG";
@@ -172,18 +172,14 @@ namespace Trainer_v5
 
 		public static string GetGameVersion()
 		{
-#if !SWINCBETA && !SWINCRELEASE
-			return "1.6";
-#elif SWINCBETA1_7
-			return "1.7";
-#elif SWINCBETA1_8
+#if SWINCBETA1_8
 			return "1.8";
 #elif SWINCBETA1_9
 			return "1.9";
 #elif SWINCBETA1_10
 			return "1.10";
 #else
-			return "UNKNOWN";
+			return "1.7";
 #endif
 		}
 	}

--- a/Trainer_v5/Trainer.Source/Helpers.cs
+++ b/Trainer_v5/Trainer.Source/Helpers.cs
@@ -172,14 +172,18 @@ namespace Trainer_v5
 
 		public static string GetGameVersion()
 		{
-#if SWINCBETA1_8
+#if !SWINCBETA && !SWINCRELEASE
+			return "1.6";
+#elif SWINCBETA1_7
+			return "1.7";
+#elif SWINCBETA1_8
 			return "1.8";
 #elif SWINCBETA1_9
 			return "1.9";
 #elif SWINCBETA1_10
 			return "1.10";
 #else
-			return "1.7";
+			return "UNKNOWN";
 #endif
 		}
 	}

--- a/Trainer_v5/Trainer.Source/TrainerBehaviour.cs
+++ b/Trainer_v5/Trainer.Source/TrainerBehaviour.cs
@@ -485,7 +485,6 @@ namespace Trainer_v5
 
 			if (Helpers.GetProperty(TrainerSettings, "DigitalDistributionMonopol"))
 			{
-#if DEBUG || SWINCBETA1_7 || SWINCBETA1_8 || SWINCBETA1_9 || SWINCBETA1_10
 				foreach (var company in Settings.simulation.Companies.Values.ToList())
 				{
 					if (company.Bankrupt && company.Distribution != null)
@@ -506,7 +505,6 @@ namespace Trainer_v5
 					company.Distribution.MarketShare = 0f;
 					MarketSimulation.Active.ClosePlatform(company.Distribution);
 				}
-#endif
 			}
 
 			/*
@@ -535,7 +533,6 @@ namespace Trainer_v5
 
 			if (Helpers.GetProperty(TrainerSettings, "AutoAcceptHostingDeals"))
 			{
-#if DEBUG || SWINCBETA1_7 || SWINCBETA1_8 || SWINCBETA1_9 || SWINCBETA1_10
 				var serverGroups = Settings.GetAllServerGroups().ToList();
 				if (serverGroups.Count == 0)
 					return;
@@ -560,7 +557,6 @@ namespace Trainer_v5
 						Settings.RegisterWithServer(mostPowerfulServerGroup.Name, serverDeal);
 					}
 				}
-#endif
 			}
 
 			GameSettings.MaxFloor = Constants.MAX_FLOOR;

--- a/Trainer_v5/Trainer.Source/TrainerBehaviour.cs
+++ b/Trainer_v5/Trainer.Source/TrainerBehaviour.cs
@@ -849,11 +849,7 @@ namespace Trainer_v5
 
 				foreach (SoftwareType t in softwareTypes)
 				{
-#if DEBUG || SWINCBETA1_7 || SWINCBETA1_8 || SWINCBETA1_9 || SWINCBETA1_10
 					actor.employee.LeadSpecializationFix[t.ToString()] = 1f;
-#else
-					actor.employee.LeadSpecialization[t] = 1f;
-#endif
 				}
 
 				foreach (Employee.EmployeeRole employeeRole in employeeRoles)

--- a/Trainer_v5/Trainer.Source/Window/EmployeeLeadSpecChangeWindow.cs
+++ b/Trainer_v5/Trainer.Source/Window/EmployeeLeadSpecChangeWindow.cs
@@ -134,11 +134,7 @@ namespace Trainer_v5.Trainer.Source.Window
 				{
 					foreach (var type in selectTypes)
 					{
-#if DEBUG || SWINCBETA1_7 || SWINCBETA1_8 || SWINCBETA1_9 || SWINCBETA1_10
 						employee.LeadSpecializationFix[type.ToString()] = val;
-#else
-						employee.LeadSpecialization[type] = val;
-#endif
 					}
 				},
 				min: 0, max: 1

--- a/Trainer_v5/Trainer_v5.csproj
+++ b/Trainer_v5/Trainer_v5.csproj
@@ -27,12 +27,6 @@
 		<DebugType>full</DebugType>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'SWINCBETA1_6|AnyCPU'">
-		<DebugSymbols>true</DebugSymbols>
-		<DefineConstants>DEBUG;TRACE</DefineConstants>
-		<DebugType>full</DebugType>
-	</PropertyGroup>
-
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'SWINCBETA|AnyCPU'">
 	</PropertyGroup>
 

--- a/Trainer_v5/Trainer_v5.csproj
+++ b/Trainer_v5/Trainer_v5.csproj
@@ -27,6 +27,12 @@
 		<DebugType>full</DebugType>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'SWINCBETA1_6|AnyCPU'">
+		<DebugSymbols>true</DebugSymbols>
+		<DefineConstants>DEBUG;TRACE</DefineConstants>
+		<DebugType>full</DebugType>
+	</PropertyGroup>
+
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'SWINCBETA|AnyCPU'">
 	</PropertyGroup>
 

--- a/docs/project/architecture.md
+++ b/docs/project/architecture.md
@@ -146,10 +146,10 @@ partially-working or version-specific features are guarded (see Cross-Cutting).
 - **Build configurations / conditional compilation.** The solution defines
   `Debug`, `Release`, `SWINCBETA`, `SWINCBETA1_7`, and `SWINCRELEASE`
   configurations. Code adapts to game versions via preprocessor symbols
-  (`SWINCBETA1_7`/`1_8`/`1_9`/`1_10`, `DEBUG`), for example gating features
-  such as `MaxMarketShare`, `AutoAcceptHostingDeals`, and
-  `DigitalDistributionMonopol`. `Helpers.GetGameVersion` maps these symbols to a
-  displayed version string.
+  (`SWINCBETA1_7`/`1_8`/`1_9`/`1_10`, `DEBUG`), for example gating the
+  `MaxMarketShare` and `AutoMaxMarketShare` features, which require a game build
+  that exposes `SoftwareProduct.MarketShare`. `Helpers.GetGameVersion` maps these
+  symbols to a displayed version string.
 - **Version source of truth.** `Helpers.Version` (currently `5.2.7`) is the
   single semantic version; the release and nightly workflows parse it from
   `Helpers.cs`.

--- a/docs/project/architecture.md
+++ b/docs/project/architecture.md
@@ -2,7 +2,7 @@
 
 **Project**: T5B1 - Software Inc. Trainer (v5, Beta 1)
 **Status**: Active
-**Last Updated**: 2026-07-07
+**Last Updated**: 2026-09-09
 
 This document describes the verified current technical system. Proposed changes
 belong under `docs/project/designs/` until accepted or implemented.
@@ -146,12 +146,12 @@ partially-working or version-specific features are guarded (see Cross-Cutting).
 - **Build configurations / conditional compilation.** The solution defines
   `Debug`, `Release`, `SWINCBETA`, `SWINCBETA1_7`, and `SWINCRELEASE`
   configurations. Code adapts to game versions via preprocessor symbols
-  (`SWINCBETA1_7`/`1_8`/`1_9`/`1_10`, `DEBUG`), for example choosing
-  `Employee.LeadSpecializationFix` vs `LeadSpecialization` and gating features
+  (`SWINCBETA1_7`/`1_8`/`1_9`/`1_10`, `DEBUG`), for example gating features
   such as `MaxMarketShare`, `AutoAcceptHostingDeals`, and
   `DigitalDistributionMonopol`. `Helpers.GetGameVersion` maps these symbols to a
-  displayed version string.
-- **Version source of truth.** `Helpers.Version` (currently `5.2.6`) is the
+  displayed version string. The oldest supported target is Beta 1.7; support
+  for Beta 1.6 has been removed.
+- **Version source of truth.** `Helpers.Version` (currently `5.2.7`) is the
   single semantic version; the release and nightly workflows parse it from
   `Helpers.cs`.
 - **Packaging / deployment.** The Release build produces `Trainer_v5.dll`, which

--- a/docs/project/architecture.md
+++ b/docs/project/architecture.md
@@ -2,7 +2,7 @@
 
 **Project**: T5B1 - Software Inc. Trainer (v5, Beta 1)
 **Status**: Active
-**Last Updated**: 2026-09-09
+**Last Updated**: 2026-09-10
 
 This document describes the verified current technical system. Proposed changes
 belong under `docs/project/designs/` until accepted or implemented.
@@ -149,8 +149,7 @@ partially-working or version-specific features are guarded (see Cross-Cutting).
   (`SWINCBETA1_7`/`1_8`/`1_9`/`1_10`, `DEBUG`), for example gating features
   such as `MaxMarketShare`, `AutoAcceptHostingDeals`, and
   `DigitalDistributionMonopol`. `Helpers.GetGameVersion` maps these symbols to a
-  displayed version string. The oldest supported target is Beta 1.7; support
-  for Beta 1.6 has been removed.
+  displayed version string.
 - **Version source of truth.** `Helpers.Version` (currently `5.2.7`) is the
   single semantic version; the release and nightly workflows parse it from
   `Helpers.cs`.


### PR DESCRIPTION
## Summary
- Clean up the mod's version-conditional compilation. Two features that were silently compiled out of Release builds are restored, the lead-specialization setters are simplified to a single code path, the version is bumped, and the changelog is reformatted. Beta 1.6 support is retained.

## The Release-build bug
No build configuration defines the `SWINCBETA*` preprocessor symbols (every `DefineConstants` sets only `DEBUG;TRACE` or `TRACE`, and there is no `Directory.Build.props`). CI builds `Debug`, but the **release and nightly workflows build `Release`** — which defines neither `DEBUG` nor any `SWINCBETA*`. So blocks guarded by `#if DEBUG || SWINCBETA1_7 || …` were present in Debug/CI but **compiled out of every shipped binary**, leaving their toggles inert for users.

Verified against the bundled `Assembly-CSharp.dll` (metadata decompile): the APIs these two features use already exist in that assembly (they compile under `DEBUG`), so removing the guards is compile-safe.

## Changes
- **Restore two features to Release builds** — remove the `#if DEBUG || SWINCBETA1_7 || … #endif` guards around **Digital Distribution Monopol** and **Auto Accept Hosting Deals** in `TrainerBehaviour.cs`; the bodies are now unconditional.
- **Simplify lead-spec setters** — remove the `#if/#else` blocks in `TrainerBehaviour.cs` and `EmployeeLeadSpecChangeWindow.cs`; they now always use `LeadSpecializationFix` (`Dictionary<string,float>`, confirmed present in the assembly).
- Bump `Helpers.Version` to `5.2.7`.
- Reformat `CHANGELOG.md` to flat per-version entries (no `Added`/`Changed`/`Removed` subheadings); add `5.2.7`, keep `5.2.6`, and renumber the older duplicate `5.2.5` (2025-10-08) to `5.2.4` for a monotonic sequence.
- Update `architecture.md` accordingly.

## Left as-is (deliberately)
- **Max Market Share / Auto Max Market Share** keep their `#if SWINCBETA1_7 || … #endif` guards. The decompile shows they call `SoftwareProduct.MarketShare`, which **does not exist** in the bundled assembly (only `DistributionPlatform` has `MarketShare`), so that code cannot compile here — the guard is correct. Enabling those features requires bundling a newer game assembly.
- `SWINCBETA1_6` build configuration and the `GetGameVersion` `"1.6"` branch are untouched.

## Validation
- [ ] Build ran or skip reason documented — **skipped:** no .NET SDK in this environment (targets `net46`, needs the game/Unity assemblies). CI is the authoritative gate. Guard removals are compile-safe because the same code already compiled under `DEBUG` against the committed assembly; API existence was independently confirmed by decompiling the bundled `Assembly-CSharp.dll`.
- [x] Implementation rechecked against task/changed files and the assembly's real API surface

## Branching / Merge Safety
- [x] Work on a task branch; name follows `feature/<short-kebab-description>` (`feature/simplify-lead-spec-setters`)
- [x] PR targets `develop`; no auto-merge / no protection bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMKfVwLiRhKKqq4NQsnidM